### PR TITLE
refactor: Improve authority validation on `close`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1731,9 +1731,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pinocchio"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2999d06e0c7b659daa8d41d56d906c26531e551d22e49c044339024d3e195ebc"
+checksum = "43a8a77bf74e1c4050a2bad53648acfcfbf22b1806473f9c9334a58ef3b38ec4"
 
 [[package]]
 name = "pinocchio-pubkey"

--- a/program/src/processor/mod.rs
+++ b/program/src/processor/mod.rs
@@ -1,6 +1,6 @@
 use pinocchio::{account_info::AccountInfo, program_error::ProgramError, pubkey::Pubkey};
 
-use crate::state::{header::Header, AccountDiscriminator};
+use crate::state::{header::Header, AccountDiscriminator, PdaInfo};
 
 pub mod allocate;
 pub mod close;
@@ -113,8 +113,8 @@ fn validate_metadata(metadata: &AccountInfo) -> Result<&Header, ProgramError> {
 /// - [explicit] The `authority` account must match the authority set on the `metadata` account OR
 ///   it must be the program upgrade authority if the `metadata` account is canonical (see `is_program_authority`).
 #[inline(always)]
-fn validate_authority(
-    metadata_header: &Header,
+fn validate_authority<T: PdaInfo>(
+    pda_info: &T,
     authority: &AccountInfo,
     program: &AccountInfo,
     program_data: &AccountInfo,
@@ -124,14 +124,14 @@ fn validate_authority(
         return Err(ProgramError::MissingRequiredSignature);
     }
     // The authority is the set authority.
-    let explicitly_authorized = match metadata_header.authority.as_ref() {
+    let explicitly_authorized = match pda_info.authority() {
         Some(metadata_authority) => metadata_authority == authority.key(),
         None => false,
     };
     // The authority is the program upgrade authority for canonical metadata accounts.
     let authorized = explicitly_authorized
-        || (metadata_header.canonical()
-            && program.key() == &metadata_header.program
+        || (pda_info.is_canonical()
+            && program.key() == pda_info.program()
             && is_program_authority(program, program_data, authority.key())?);
     if !authorized {
         return Err(ProgramError::IncorrectAuthority);

--- a/program/src/processor/mod.rs
+++ b/program/src/processor/mod.rs
@@ -131,7 +131,7 @@ fn validate_authority<T: PdaInfo>(
     // The authority is the program upgrade authority for canonical metadata accounts.
     let authorized = explicitly_authorized
         || (pda_info.is_canonical()
-            && program.key() == pda_info.program()
+            && pda_info.program() == Some(program.key())
             && is_program_authority(program, program_data, authority.key())?);
     if !authorized {
         return Err(ProgramError::IncorrectAuthority);

--- a/program/src/state/buffer.rs
+++ b/program/src/state/buffer.rs
@@ -76,6 +76,6 @@ impl PdaInfo for Buffer {
     }
 
     fn is_canonical(&self) -> bool {
-        self.canonical() && self.authority().is_none()
+        self.canonical()
     }
 }

--- a/program/src/state/buffer.rs
+++ b/program/src/state/buffer.rs
@@ -67,8 +67,8 @@ impl Buffer {
 }
 
 impl PdaInfo for Buffer {
-    fn program(&self) -> &Pubkey {
-        self.program.as_ref().unwrap()
+    fn program(&self) -> Option<&Pubkey> {
+        self.program.as_ref()
     }
 
     fn authority(&self) -> Option<&Pubkey> {

--- a/program/src/state/buffer.rs
+++ b/program/src/state/buffer.rs
@@ -1,6 +1,6 @@
 use pinocchio::{program_error::ProgramError, pubkey::Pubkey};
 
-use super::{AccountDiscriminator, ZeroableOption, SEED_LEN};
+use super::{AccountDiscriminator, PdaInfo, ZeroableOption, SEED_LEN};
 
 /// Buffer account header.
 #[repr(C)]
@@ -63,5 +63,19 @@ impl Buffer {
 
     pub(crate) unsafe fn load_mut_unchecked(bytes: &mut [u8]) -> &mut Self {
         &mut *(bytes.as_mut_ptr() as *mut Self)
+    }
+}
+
+impl PdaInfo for Buffer {
+    fn program(&self) -> &Pubkey {
+        self.program.as_ref().unwrap()
+    }
+
+    fn authority(&self) -> Option<&Pubkey> {
+        self.authority.as_ref()
+    }
+
+    fn is_canonical(&self) -> bool {
+        self.canonical() && self.authority().is_none()
     }
 }

--- a/program/src/state/buffer.rs
+++ b/program/src/state/buffer.rs
@@ -1,6 +1,6 @@
 use pinocchio::{program_error::ProgramError, pubkey::Pubkey};
 
-use super::{AccountDiscriminator, PdaInfo, ZeroableOption, SEED_LEN};
+use super::{Account, AccountDiscriminator, ZeroableOption, SEED_LEN};
 
 /// Buffer account header.
 #[repr(C)]
@@ -66,16 +66,12 @@ impl Buffer {
     }
 }
 
-impl PdaInfo for Buffer {
-    fn program(&self) -> Option<&Pubkey> {
-        self.program.as_ref()
-    }
-
-    fn authority(&self) -> Option<&Pubkey> {
+impl Account for Buffer {
+    fn get_authority(&self) -> Option<&Pubkey> {
         self.authority.as_ref()
     }
 
-    fn is_canonical(&self) -> bool {
-        self.canonical()
+    fn is_canonical(&self, program: &Pubkey) -> bool {
+        self.canonical() && self.program.as_ref() == Some(program)
     }
 }

--- a/program/src/state/header.rs
+++ b/program/src/state/header.rs
@@ -1,7 +1,8 @@
 use pinocchio::{program_error::ProgramError, pubkey::Pubkey};
 
 use super::{
-    AccountDiscriminator, Compression, DataSource, Encoding, Format, ZeroableOption, SEED_LEN,
+    AccountDiscriminator, Compression, DataSource, Encoding, Format, PdaInfo, ZeroableOption,
+    SEED_LEN,
 };
 
 /// Metadata account header.
@@ -104,5 +105,19 @@ impl Header {
 
     pub(crate) unsafe fn load_mut_unchecked(bytes: &mut [u8]) -> &mut Self {
         &mut *(bytes.as_mut_ptr() as *mut Self)
+    }
+}
+
+impl PdaInfo for Header {
+    fn program(&self) -> &Pubkey {
+        &self.program
+    }
+
+    fn authority(&self) -> Option<&Pubkey> {
+        self.authority.as_ref()
+    }
+
+    fn is_canonical(&self) -> bool {
+        self.canonical()
     }
 }

--- a/program/src/state/header.rs
+++ b/program/src/state/header.rs
@@ -109,8 +109,8 @@ impl Header {
 }
 
 impl PdaInfo for Header {
-    fn program(&self) -> &Pubkey {
-        &self.program
+    fn program(&self) -> Option<&Pubkey> {
+        Some(&self.program)
     }
 
     fn authority(&self) -> Option<&Pubkey> {

--- a/program/src/state/header.rs
+++ b/program/src/state/header.rs
@@ -1,7 +1,7 @@
 use pinocchio::{program_error::ProgramError, pubkey::Pubkey};
 
 use super::{
-    AccountDiscriminator, Compression, DataSource, Encoding, Format, PdaInfo, ZeroableOption,
+    Account, AccountDiscriminator, Compression, DataSource, Encoding, Format, ZeroableOption,
     SEED_LEN,
 };
 
@@ -108,16 +108,12 @@ impl Header {
     }
 }
 
-impl PdaInfo for Header {
-    fn program(&self) -> Option<&Pubkey> {
-        Some(&self.program)
-    }
-
-    fn authority(&self) -> Option<&Pubkey> {
+impl Account for Header {
+    fn get_authority(&self) -> Option<&Pubkey> {
         self.authority.as_ref()
     }
 
-    fn is_canonical(&self) -> bool {
-        self.canonical()
+    fn is_canonical(&self, program: &Pubkey) -> bool {
+        self.canonical() && self.program == *program
     }
 }

--- a/program/src/state/mod.rs
+++ b/program/src/state/mod.rs
@@ -35,7 +35,7 @@ impl<'a> Metadata<'a> {
 /// Trait representing the common information of a PDA account.
 pub(crate) trait PdaInfo {
     /// The program that this PDA is associated with.
-    fn program(&self) -> &Pubkey;
+    fn program(&self) -> Option<&Pubkey>;
 
     /// The (optional) authority of the PDA.
     fn authority(&self) -> Option<&Pubkey>;

--- a/program/src/state/mod.rs
+++ b/program/src/state/mod.rs
@@ -32,17 +32,14 @@ impl<'a> Metadata<'a> {
     }
 }
 
-/// Trait representing the common information of a PDA account.
-pub(crate) trait PdaInfo {
-    /// The program that this PDA is associated with.
-    fn program(&self) -> Option<&Pubkey>;
-
-    /// The (optional) authority of the PDA.
-    fn authority(&self) -> Option<&Pubkey>;
+/// Utility trait for an account.
+pub(crate) trait Account {
+    /// Returns the account authority, if there is one.
+    fn get_authority(&self) -> Option<&Pubkey>;
 
     /// Indicates whether the PDA represents a canonical PDA for
-    /// the program.
-    fn is_canonical(&self) -> bool;
+    /// the given program.
+    fn is_canonical(&self, program: &Pubkey) -> bool;
 }
 
 /// Account discriminators.

--- a/program/src/state/mod.rs
+++ b/program/src/state/mod.rs
@@ -32,6 +32,19 @@ impl<'a> Metadata<'a> {
     }
 }
 
+/// Trait representing the common information of a PDA account.
+pub(crate) trait PdaInfo {
+    /// The program that this PDA is associated with.
+    fn program(&self) -> &Pubkey;
+
+    /// The (optional) authority of the PDA.
+    fn authority(&self) -> Option<&Pubkey>;
+
+    /// Indicates whether the PDA represents a canonical PDA for
+    /// the program.
+    fn is_canonical(&self) -> bool;
+}
+
 /// Account discriminators.
 #[repr(u8)]
 #[derive(Clone, Copy, Debug)]


### PR DESCRIPTION
### Problem

Currently it is not possible to close PDA buffer accounts.

### Solution

Improve the authority validation to allow closing PDA buffers. The program upgrade authority is able to close a canonical PDA buffer even if a different authority created it.