### PR TITLE
Introduce `InstructionPlan` executors in JS client

### DIFF
--- a/clients/js/src/instructionPlans/defaultInstructionPlanExecutor.ts
+++ b/clients/js/src/instructionPlans/defaultInstructionPlanExecutor.ts
@@ -1,0 +1,83 @@
+import {
+  appendTransactionMessageInstructions,
+  CompilableTransactionMessage,
+  FullySignedTransaction,
+  pipe,
+  signTransactionMessageWithSigners,
+  TransactionMessageWithBlockhashLifetime,
+  TransactionMessageWithDurableNonceLifetime,
+  TransactionWithLifetime,
+} from '@solana/web3.js';
+import { MessageInstructionPlan } from './instructionPlan';
+import {
+  chunkParallelInstructionPlans,
+  createInstructionPlanExecutor,
+  InstructionPlanExecutor,
+} from './instructionPlanExecutor';
+
+export type DefaultInstructionPlanExecutorConfig = Readonly<{
+  /**
+   * When provided, chunks the plans inside a {@link ParallelInstructionPlan}.
+   * Each chunk is executed sequentially but each plan within a chunk is
+   * executed in parallel.
+   */
+  parallelChunkSize?: number;
+
+  /**
+   * If true _and_ if the transaction message contains an instruction
+   * that sets the compute unit limit to any value, the executor will
+   * simulate the transaction to determine the optimal compute unit limit
+   * before updating the compute budget instruction with the computed value.
+   */
+  simulateComputeUnitLimit?: boolean; // TODO
+
+  /**
+   * Returns the default transaction message used to send transactions.
+   * Any instructions inside a {@link MessageInstructionPlan} will be
+   * appended to this message.
+   */
+  getDefaultMessage: (config?: {
+    abortSignal?: AbortSignal;
+  }) => Promise<
+    CompilableTransactionMessage &
+      (
+        | TransactionMessageWithBlockhashLifetime
+        | TransactionMessageWithDurableNonceLifetime
+      )
+  >;
+
+  /**
+   * Sends and confirms a constructed transaction.
+   */
+  sendAndConfirm: (
+    transaction: FullySignedTransaction & TransactionWithLifetime,
+    config?: { abortSignal?: AbortSignal }
+  ) => Promise<void>;
+}>;
+
+export function getDefaultInstructionPlanExecutor(
+  config: DefaultInstructionPlanExecutorConfig
+): InstructionPlanExecutor {
+  const {
+    getDefaultMessage,
+    parallelChunkSize: chunkSize,
+    sendAndConfirm,
+  } = config;
+
+  return async (plan, config) => {
+    const handleMessage = async (plan: MessageInstructionPlan) => {
+      const tx = await pipe(
+        await getDefaultMessage(config),
+        (tx) => appendTransactionMessageInstructions(plan.instructions, tx),
+        (tx) => signTransactionMessageWithSigners(tx)
+      );
+      await sendAndConfirm(tx, config);
+    };
+
+    const executor = pipe(createInstructionPlanExecutor(handleMessage), (e) =>
+      chunkSize ? chunkParallelInstructionPlans(e, chunkSize) : e
+    );
+
+    return await executor(plan, config);
+  };
+}

--- a/clients/js/src/instructionPlans/index.ts
+++ b/clients/js/src/instructionPlans/index.ts
@@ -1,0 +1,3 @@
+export * from './defaultInstructionPlanExecutor';
+export * from './instructionPlan';
+export * from './instructionPlanExecutor';

--- a/clients/js/src/instructionPlans/instructionPlan.ts
+++ b/clients/js/src/instructionPlans/instructionPlan.ts
@@ -1,0 +1,39 @@
+import {
+  appendTransactionMessageInstructions,
+  BaseTransactionMessage,
+  IInstruction,
+} from '@solana/web3.js';
+
+export type InstructionPlan =
+  | SequentialInstructionPlan
+  | ParallelInstructionPlan
+  | MessageInstructionPlan;
+
+export type SequentialInstructionPlan = Readonly<{
+  kind: 'sequential';
+  plans: InstructionPlan[];
+}>;
+
+export type ParallelInstructionPlan = Readonly<{
+  kind: 'parallel';
+  plans: InstructionPlan[];
+}>;
+
+export type MessageInstructionPlan<
+  TInstructions extends IInstruction[] = IInstruction[],
+> = Readonly<{
+  kind: 'message';
+  instructions: TInstructions;
+}>;
+
+export function getTransactionMessageFromPlan<
+  TTransactionMessage extends BaseTransactionMessage = BaseTransactionMessage,
+>(
+  defaultMessage: TTransactionMessage,
+  plan: MessageInstructionPlan
+): TTransactionMessage {
+  return appendTransactionMessageInstructions(
+    plan.instructions,
+    defaultMessage
+  );
+}

--- a/clients/js/src/instructionPlans/instructionPlanExecutor.ts
+++ b/clients/js/src/instructionPlans/instructionPlanExecutor.ts
@@ -1,0 +1,66 @@
+import {
+  InstructionPlan,
+  MessageInstructionPlan,
+  ParallelInstructionPlan,
+} from './instructionPlan';
+
+export type InstructionPlanExecutor = (
+  plan: InstructionPlan,
+  config?: { abortSignal?: AbortSignal }
+) => Promise<void>;
+
+export function createInstructionPlanExecutor(
+  handleMessage: (plan: MessageInstructionPlan) => Promise<void>
+): InstructionPlanExecutor {
+  return async function self(plan) {
+    switch (plan.kind) {
+      case 'sequential':
+        for (const subPlan of plan.plans) {
+          await self(subPlan);
+        }
+        break;
+      case 'parallel':
+        await Promise.all(plan.plans.map((subPlan) => self(subPlan)));
+        break;
+      case 'message':
+        return await handleMessage(plan);
+      default:
+        throw new Error('Unsupported instruction plan');
+    }
+  };
+}
+
+export function chunkParallelInstructionPlans(
+  executor: InstructionPlanExecutor,
+  chunkSize: number
+): InstructionPlanExecutor {
+  const chunkPlan = (plan: ParallelInstructionPlan) => {
+    return plan.plans
+      .reduce(
+        (chunks, subPlan) => {
+          const lastChunk = chunks[chunks.length - 1];
+          if (lastChunk && lastChunk.length < chunkSize) {
+            lastChunk.push(subPlan);
+          } else {
+            chunks.push([subPlan]);
+          }
+          return chunks;
+        },
+        [[]] as InstructionPlan[][]
+      )
+      .map((plans) => ({ kind: 'parallel', plans }) as ParallelInstructionPlan);
+  };
+  return async function self(plan, config) {
+    switch (plan.kind) {
+      case 'sequential':
+        return await self(plan, config);
+      case 'parallel':
+        for (const chunk of chunkPlan(plan)) {
+          await executor(chunk, config);
+        }
+        break;
+      default:
+        return await executor(plan, config);
+    }
+  };
+}


### PR DESCRIPTION
This PR isolates the generic `InstructionPlan` logic and adds the concept of composable `InstructionPlanExecutors` that can be used to send `InstructionPlans` used the required strategy.

This work makes it possible for a subsequent PR to add a strategy that simulates a transaction and updates the compute budget instructions with the simulated CU limit.