### PR TITLE
program: Add optional buffer to `Write` instruction

### DIFF
--- a/clients/js/src/generated/instructions/write.ts
+++ b/clients/js/src/generated/instructions/write.ts
@@ -26,6 +26,7 @@ import {
   type IInstruction,
   type IInstructionWithAccounts,
   type IInstructionWithData,
+  type ReadonlyAccount,
   type ReadonlySignerAccount,
   type ReadonlyUint8Array,
   type TransactionSigner,
@@ -44,6 +45,7 @@ export type WriteInstruction<
   TProgram extends string = typeof PROGRAM_METADATA_PROGRAM_ADDRESS,
   TAccountBuffer extends string | IAccountMeta<string> = string,
   TAccountAuthority extends string | IAccountMeta<string> = string,
+  TAccountSourceBuffer extends string | IAccountMeta<string> = string,
   TRemainingAccounts extends readonly IAccountMeta<string>[] = [],
 > = IInstruction<TProgram> &
   IInstructionWithData<Uint8Array> &
@@ -56,6 +58,9 @@ export type WriteInstruction<
         ? ReadonlySignerAccount<TAccountAuthority> &
             IAccountSignerMeta<TAccountAuthority>
         : TAccountAuthority,
+      TAccountSourceBuffer extends string
+        ? ReadonlyAccount<TAccountSourceBuffer>
+        : TAccountSourceBuffer,
       ...TRemainingAccounts,
     ]
   >;
@@ -105,11 +110,14 @@ export function getWriteInstructionDataCodec(): Codec<
 export type WriteInput<
   TAccountBuffer extends string = string,
   TAccountAuthority extends string = string,
+  TAccountSourceBuffer extends string = string,
 > = {
   /** The buffer to write to. */
   buffer: Address<TAccountBuffer>;
   /** The authority of the buffer. */
   authority: TransactionSigner<TAccountAuthority>;
+  /** Buffer to copy the data from. */
+  sourceBuffer?: Address<TAccountSourceBuffer>;
   offset: WriteInstructionDataArgs['offset'];
   data: WriteInstructionDataArgs['data'];
 };
@@ -117,11 +125,17 @@ export type WriteInput<
 export function getWriteInstruction<
   TAccountBuffer extends string,
   TAccountAuthority extends string,
+  TAccountSourceBuffer extends string,
   TProgramAddress extends Address = typeof PROGRAM_METADATA_PROGRAM_ADDRESS,
 >(
-  input: WriteInput<TAccountBuffer, TAccountAuthority>,
+  input: WriteInput<TAccountBuffer, TAccountAuthority, TAccountSourceBuffer>,
   config?: { programAddress?: TProgramAddress }
-): WriteInstruction<TProgramAddress, TAccountBuffer, TAccountAuthority> {
+): WriteInstruction<
+  TProgramAddress,
+  TAccountBuffer,
+  TAccountAuthority,
+  TAccountSourceBuffer
+> {
   // Program address.
   const programAddress =
     config?.programAddress ?? PROGRAM_METADATA_PROGRAM_ADDRESS;
@@ -130,6 +144,7 @@ export function getWriteInstruction<
   const originalAccounts = {
     buffer: { value: input.buffer ?? null, isWritable: true },
     authority: { value: input.authority ?? null, isWritable: false },
+    sourceBuffer: { value: input.sourceBuffer ?? null, isWritable: false },
   };
   const accounts = originalAccounts as Record<
     keyof typeof originalAccounts,
@@ -144,12 +159,18 @@ export function getWriteInstruction<
     accounts: [
       getAccountMeta(accounts.buffer),
       getAccountMeta(accounts.authority),
+      getAccountMeta(accounts.sourceBuffer),
     ],
     programAddress,
     data: getWriteInstructionDataEncoder().encode(
       args as WriteInstructionDataArgs
     ),
-  } as WriteInstruction<TProgramAddress, TAccountBuffer, TAccountAuthority>;
+  } as WriteInstruction<
+    TProgramAddress,
+    TAccountBuffer,
+    TAccountAuthority,
+    TAccountSourceBuffer
+  >;
 
   return instruction;
 }
@@ -164,6 +185,8 @@ export type ParsedWriteInstruction<
     buffer: TAccountMetas[0];
     /** The authority of the buffer. */
     authority: TAccountMetas[1];
+    /** Buffer to copy the data from. */
+    sourceBuffer?: TAccountMetas[2] | undefined;
   };
   data: WriteInstructionData;
 };
@@ -176,7 +199,7 @@ export function parseWriteInstruction<
     IInstructionWithAccounts<TAccountMetas> &
     IInstructionWithData<Uint8Array>
 ): ParsedWriteInstruction<TProgram, TAccountMetas> {
-  if (instruction.accounts.length < 2) {
+  if (instruction.accounts.length < 3) {
     // TODO: Coded error.
     throw new Error('Not enough accounts');
   }
@@ -186,11 +209,18 @@ export function parseWriteInstruction<
     accountIndex += 1;
     return accountMeta;
   };
+  const getNextOptionalAccount = () => {
+    const accountMeta = getNextAccount();
+    return accountMeta.address === PROGRAM_METADATA_PROGRAM_ADDRESS
+      ? undefined
+      : accountMeta;
+  };
   return {
     programAddress: instruction.programAddress,
     accounts: {
       buffer: getNextAccount(),
       authority: getNextAccount(),
+      sourceBuffer: getNextOptionalAccount(),
     },
     data: getWriteInstructionDataDecoder().decode(instruction.data),
   };

--- a/clients/rust/src/generated/instructions/write.rs
+++ b/clients/rust/src/generated/instructions/write.rs
@@ -5,9 +5,9 @@
 //! <https://github.com/codama-idl/codama>
 //!
 
+use crate::hooked::RemainderOptionBytes;
 use borsh::BorshDeserialize;
 use borsh::BorshSerialize;
-use kaigan::types::RemainderVec;
 
 /// Accounts.
 #[derive(Debug)]
@@ -17,6 +17,7 @@ pub struct Write {
     /// The authority of the buffer.
     pub authority: solana_program::pubkey::Pubkey,
     /// Buffer to copy the data from.
+    /// You may use the `data` argument instead of this account to pass data directly.
     pub source_buffer: Option<solana_program::pubkey::Pubkey>,
 }
 
@@ -89,7 +90,7 @@ impl Default for WriteInstructionData {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct WriteInstructionArgs {
     pub offset: u32,
-    pub data: RemainderVec<u8>,
+    pub data: RemainderOptionBytes,
 }
 
 /// Instruction builder for `Write`.
@@ -105,7 +106,7 @@ pub struct WriteBuilder {
     authority: Option<solana_program::pubkey::Pubkey>,
     source_buffer: Option<solana_program::pubkey::Pubkey>,
     offset: Option<u32>,
-    data: Option<RemainderVec<u8>>,
+    data: Option<RemainderOptionBytes>,
     __remaining_accounts: Vec<solana_program::instruction::AccountMeta>,
 }
 
@@ -127,6 +128,7 @@ impl WriteBuilder {
     }
     /// `[optional account]`
     /// Buffer to copy the data from.
+    /// You may use the `data` argument instead of this account to pass data directly.
     #[inline(always)]
     pub fn source_buffer(
         &mut self,
@@ -141,7 +143,7 @@ impl WriteBuilder {
         self
     }
     #[inline(always)]
-    pub fn data(&mut self, data: RemainderVec<u8>) -> &mut Self {
+    pub fn data(&mut self, data: RemainderOptionBytes) -> &mut Self {
         self.data = Some(data);
         self
     }
@@ -186,6 +188,7 @@ pub struct WriteCpiAccounts<'a, 'b> {
     /// The authority of the buffer.
     pub authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Buffer to copy the data from.
+    /// You may use the `data` argument instead of this account to pass data directly.
     pub source_buffer: Option<&'b solana_program::account_info::AccountInfo<'a>>,
 }
 
@@ -198,6 +201,7 @@ pub struct WriteCpi<'a, 'b> {
     /// The authority of the buffer.
     pub authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Buffer to copy the data from.
+    /// You may use the `data` argument instead of this account to pass data directly.
     pub source_buffer: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// The arguments for the instruction.
     pub __args: WriteInstructionArgs,
@@ -351,6 +355,7 @@ impl<'a, 'b> WriteCpiBuilder<'a, 'b> {
     }
     /// `[optional account]`
     /// Buffer to copy the data from.
+    /// You may use the `data` argument instead of this account to pass data directly.
     #[inline(always)]
     pub fn source_buffer(
         &mut self,
@@ -365,7 +370,7 @@ impl<'a, 'b> WriteCpiBuilder<'a, 'b> {
         self
     }
     #[inline(always)]
-    pub fn data(&mut self, data: RemainderVec<u8>) -> &mut Self {
+    pub fn data(&mut self, data: RemainderOptionBytes) -> &mut Self {
         self.instruction.data = Some(data);
         self
     }
@@ -438,7 +443,7 @@ struct WriteCpiBuilderInstruction<'a, 'b> {
     authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     source_buffer: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     offset: Option<u32>,
-    data: Option<RemainderVec<u8>>,
+    data: Option<RemainderOptionBytes>,
     /// Additional instruction accounts `(AccountInfo, is_writable, is_signer)`.
     __remaining_accounts: Vec<(
         &'b solana_program::account_info::AccountInfo<'a>,

--- a/program/idl.json
+++ b/program/idl.json
@@ -311,6 +311,14 @@
             "docs": ["The authority of the buffer."],
             "isSigner": true,
             "isWritable": false
+          },
+          {
+            "kind": "instructionAccountNode",
+            "name": "sourceBuffer",
+            "docs": ["Buffer to copy the data from."],
+            "isSigner": false,
+            "isWritable": false,
+            "isOptional": true
           }
         ],
         "arguments": [

--- a/program/idl.json
+++ b/program/idl.json
@@ -315,7 +315,10 @@
           {
             "kind": "instructionAccountNode",
             "name": "sourceBuffer",
-            "docs": ["Buffer to copy the data from."],
+            "docs": [
+              "Buffer to copy the data from.",
+              "You may use the `data` argument instead of this account to pass data directly."
+            ],
             "isSigner": false,
             "isWritable": false,
             "isOptional": true
@@ -347,8 +350,15 @@
           {
             "kind": "instructionArgumentNode",
             "name": "data",
-            "docs": [],
-            "type": { "kind": "bytesTypeNode" }
+            "docs": [
+              "The data to write at the provided offset.",
+              "You may use the `source_buffer` account instead of this argument to copy from an existing buffer."
+            ],
+            "defaultValue": { "kind": "noneValueNode" },
+            "type": {
+              "kind": "remainderOptionTypeNode",
+              "item": { "kind": "bytesTypeNode" }
+            }
           }
         ],
         "discriminators": [

--- a/program/src/instruction.rs
+++ b/program/src/instruction.rs
@@ -12,11 +12,12 @@ pub enum ProgramMetadataInstruction {
     ///
     /// 0. `[w]` Buffer to write to.
     /// 1. `[s]` Authority account.
+    /// 2. `[o]` Buffer to copy the data from.
     ///
     /// Instruction data:
     ///
     /// - `u32`: offset to write to
-    /// - `[u8]`: bytes to write
+    /// - `[u8]`: (optional) bytes to write
     Write,
 
     /// Initializes a metadata account.

--- a/program/src/processor/initialize.rs
+++ b/program/src/processor/initialize.rs
@@ -75,7 +75,7 @@ pub fn initialize(accounts: &[AccountInfo], instruction_data: &[u8]) -> ProgramR
 
     let discriminator = {
         // SAFETY: scoped immutable borrow of `metadata` account data.
-        AccountDiscriminator::from_bytes(unsafe { metadata.borrow_data_unchecked() })?
+        AccountDiscriminator::try_from_bytes(unsafe { metadata.borrow_data_unchecked() })?
     };
 
     let data_length = match discriminator {

--- a/program/src/processor/set_authority.rs
+++ b/program/src/processor/set_authority.rs
@@ -38,7 +38,7 @@ pub fn set_authority(accounts: &[AccountInfo], instruction_data: &[u8]) -> Progr
     // SAFETY: single mutable borrow of `account` account data.
     let account_data = unsafe { account.borrow_mut_data_unchecked() };
 
-    match AccountDiscriminator::from_bytes(account_data)? {
+    match AccountDiscriminator::try_from_bytes(account_data)? {
         Some(AccountDiscriminator::Buffer) => {
             let buffer = Buffer::from_bytes_mut(account_data)?;
 

--- a/program/src/processor/write.rs
+++ b/program/src/processor/write.rs
@@ -4,7 +4,7 @@ use pinocchio::{
     account_info::AccountInfo, memory::sol_memcpy, program_error::ProgramError, ProgramResult,
 };
 
-use crate::state::{buffer::Buffer, AccountDiscriminator};
+use crate::state::{buffer::Buffer, header::Header, AccountDiscriminator};
 
 /// Processor for the [`Write`](`crate::instruction::ProgramMetadataInstruction::Write`)
 /// instruction.
@@ -16,7 +16,7 @@ pub fn write(accounts: &[AccountInfo], instruction_data: &[u8]) -> ProgramResult
 
     // Access accounts.
 
-    let [buffer, authority, _remaining @ ..] = accounts else {
+    let [target_buffer, authority, source_buffer, _remaining @ ..] = accounts else {
         return Err(ProgramError::NotEnoughAccountKeys);
     };
 
@@ -29,15 +29,15 @@ pub fn write(accounts: &[AccountInfo], instruction_data: &[u8]) -> ProgramResult
         return Err(ProgramError::MissingRequiredSignature);
     }
 
-    // buffer
+    // target_buffer
     // - must be initialized
     // - must be rent exempt (pre-funded account) since we are reallocating the buffer
     //   account (this is tested implicity)
 
-    let required_length = {
+    let (required_length, source_data) = {
         // SAFETY: scoped immutable borrow of `buffer` account data. There
         // are no other borrows active.
-        let data = unsafe { buffer.borrow_data_unchecked() };
+        let data = unsafe { target_buffer.borrow_data_unchecked() };
 
         if data.is_empty() || data[0] != AccountDiscriminator::Buffer as u8 {
             return Err(ProgramError::InvalidAccountData);
@@ -50,22 +50,43 @@ pub fn write(accounts: &[AccountInfo], instruction_data: &[u8]) -> ProgramResult
             return Err(ProgramError::IncorrectAuthority);
         }
 
-        max(data.len(), offset + args.data().len())
+        // Determine from where to copy the data.
+        let instruction_data = match args.data() {
+            source_data if !source_data.is_empty() => Some(source_data),
+            _ => None,
+        };
+
+        let buffer_data = if source_buffer.key() != &crate::ID {
+            // SAFETY: singe immutable borrow of `source_buffer` account data.
+            Some(unsafe { source_buffer.borrow_data_unchecked() })
+        } else {
+            None
+        };
+
+        let source_data = match (instruction_data, buffer_data) {
+            (Some(instruction_data), None) => instruction_data,
+            (None, Some(buffer_data)) => match AccountDiscriminator::try_from_bytes(buffer_data)? {
+                Some(AccountDiscriminator::Buffer) => &buffer_data[Header::LEN..],
+                _ => return Err(ProgramError::InvalidAccountData),
+            },
+            _ => return Err(ProgramError::InvalidInstructionData),
+        };
+
+        (max(data.len(), offset + source_data.len()), source_data)
     };
 
-    // Writes the instruction data to the buffer account.
+    // Writes the source data to the buffer account.
 
-    buffer.realloc(required_length, false)?;
+    target_buffer.realloc(required_length, false)?;
     // SAFETY: single mutable borrow of `buffer` account data. There
     // are no other borrows active.
-    let data = unsafe { buffer.borrow_mut_data_unchecked() };
-    let instruction_data = args.data();
+    let data = unsafe { target_buffer.borrow_mut_data_unchecked() };
 
     unsafe {
         sol_memcpy(
-            &mut data[offset..],
-            instruction_data,
-            instruction_data.len(),
+            data.get_unchecked_mut(offset..),
+            source_data,
+            source_data.len(),
         );
     }
 
@@ -86,8 +107,8 @@ impl Write<'_> {
     pub fn try_from_bytes(bytes: &[u8]) -> Result<Write, ProgramError> {
         // The minimum expected size of the instruction data.
         // - offset (4 bytes)
-        // - data (...n bytes)
-        if bytes.len() < 5 {
+        // - data (...n bytes, optional)
+        if bytes.len() < 4 {
             return Err(ProgramError::InvalidInstructionData);
         }
 

--- a/program/src/state/mod.rs
+++ b/program/src/state/mod.rs
@@ -69,12 +69,12 @@ pub enum AccountDiscriminator {
 }
 
 impl AccountDiscriminator {
-    pub fn from_bytes(bytes: &[u8]) -> Result<Option<AccountDiscriminator>, ProgramError> {
-        if bytes.is_empty() {
-            Ok(None)
+    pub fn try_from_bytes(bytes: &[u8]) -> Result<Option<AccountDiscriminator>, ProgramError> {
+        Ok(if let Some(discriminator) = bytes.first() {
+            Some(AccountDiscriminator::try_from(*discriminator)?)
         } else {
-            Ok(Some(AccountDiscriminator::try_from(bytes[0])?))
-        }
+            None
+        })
     }
 }
 


### PR DESCRIPTION
### Problem

Currently, the `Write` instruction only accepts the data to write as instruction data. This limits each write to the maximum transaction size.

### Solution

Add an optional buffer account to allow passing more data for a single write. This is useful when writing to PDA accounts controlled by multisigs, since the process of writing the data to a buffer can be done by a separate keypair.