### PR TITLE
Use security.txt macro

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4804,6 +4804,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-security-txt"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "468aa43b7edb1f9b7b7b686d5c3aeb6630dc1708e86e31343499dd5c4d775183"
+
+[[package]]
 name = "solana-seed-derivable"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5394,6 +5400,7 @@ dependencies = [
  "pinocchio-pubkey",
  "pinocchio-system",
  "solana-sdk",
+ "solana-security-txt",
 ]
 
 [[package]]

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,22 @@
+# Security Policy
+
+## Reporting security problems
+
+**DO NOT CREATE A GITHUB ISSUE** to report a security problem.
+
+Instead please use this [Report a Vulnerability](https://github.com/solana-program/program-metadata/security/advisories/new) link.
+Provide a helpful title and detailed description of the problem.
+
+If you haven't done so already, please **enable two-factor auth** in your GitHub account.
+
+Expect a response as fast as possible in the advisory, typically within 72 hours.
+
+If you do not receive a response in the advisory, send an email to
+<security@anza.xyz> with the full URL of the advisory you have created. DO NOT
+include attachments or provide detail sufficient for exploitation regarding the
+security issue in this email. **Only provide such details in the advisory**.
+
+If you do not receive a response from <security@anza.xyz> please followup with
+the team directly. You can do this in one of the `#Dev Tooling` channels of the
+[Solana Tech discord server](https://solana.com/discord), by pinging the admins
+in the channel and referencing the fact that you submitted a security problem.

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -23,6 +23,7 @@ crate-type = ["cdylib", "lib"]
 pinocchio = "0.8"
 pinocchio-pubkey = "0.2"
 pinocchio-system = "0.2"
+solana-security-txt = "1.1.1"
 
 [dev-dependencies]
 mollusk-svm = "0.1"

--- a/program/src/lib.rs
+++ b/program/src/lib.rs
@@ -9,3 +9,15 @@ pub mod processor;
 pub mod state;
 
 pinocchio_pubkey::declare_id!("ProgM6JCCvbYkfKqJYHePx4xxSUSqJp7rh8Lyv7nk7S");
+
+solana_security_txt::security_txt! {
+    // Required fields
+    name: "SPL Program Metadata",
+    project_url: "https://github.com/solana-program/program-metadata",
+    contacts: "link:https://github.com/solana-program/program-metadata/security/advisories/new,email:security@anza.xyz,link:https://solana.com/discord",
+    policy: "https://github.com/solana-program/program-metadata/blob/master/SECURITY.md",
+
+    // Optional Fields
+    preferred_languages: "en",
+    source_code: "https://github.com/solana-program/program-metadata/tree/master/program"
+}


### PR DESCRIPTION
### Problem

Currently there is no information under `security.txt` on explorers for the program.

### Solution

Add the `security.txt` information.

![image](https://github.com/user-attachments/assets/bc9cd2a8-9682-4f5a-ab0b-8fad141267c3)
