### PR TITLE
Fix npx CLI issue by using a more robust entrypoint

### DIFF
--- a/clients/js/.eslintrc.cjs
+++ b/clients/js/.eslintrc.cjs
@@ -1,6 +1,11 @@
 module.exports = {
   extends: ['@solana/eslint-config-solana'],
-  ignorePatterns: ['.eslintrc.cjs', 'tsup.config.ts', 'env-shim.ts'],
+  ignorePatterns: [
+    '.eslintrc.cjs',
+    'tsup.config.ts',
+    'env-shim.ts',
+    'bin/cli.cjs',
+  ],
   parserOptions: {
     project: 'tsconfig.json',
     tsconfigRootDir: __dirname,

--- a/clients/js/bin/cli.cjs
+++ b/clients/js/bin/cli.cjs
@@ -1,0 +1,5 @@
+#!/usr/bin/env -S node
+
+const run = require('../dist/src/cli.js').run;
+
+run(process.argv);

--- a/clients/js/package.json
+++ b/clients/js/package.json
@@ -15,7 +15,7 @@
     }
   },
   "bin": {
-    "program-metadata": "./dist/src/cli.js"
+    "program-metadata": "./bin/cli.cjs"
   },
   "files": [
     "./dist/src",

--- a/clients/js/src/cli/index.ts
+++ b/clients/js/src/cli/index.ts
@@ -1,1 +1,16 @@
-export * from './program';
+import { logDebug, logError } from './logs';
+import { createProgram } from './program';
+
+const program = createProgram();
+
+export async function run(argv: readonly string[]) {
+  try {
+    await program.parseAsync(argv);
+  } catch (err) {
+    if (program.opts().debug) {
+      logDebug(`${(err as { stack: string }).stack}`);
+    }
+    logError((err as { message: string }).message);
+    process.exitCode = 1;
+  }
+}

--- a/clients/js/src/cli/logs.ts
+++ b/clients/js/src/cli/logs.ts
@@ -59,6 +59,10 @@ export function logError(message: string): void {
   console.error(picocolors.red(`[Error] `) + message);
 }
 
+export function logDebug(message: string): void {
+  console.debug(picocolors.magenta(`[Debug] `) + message);
+}
+
 export function logErrorAndExit(message: string): never {
   logError(message);
   process.exit(1);

--- a/clients/js/src/cli/program.ts
+++ b/clients/js/src/cli/program.ts
@@ -1,16 +1,40 @@
-#!/usr/bin/env node
-
 import { setCommands } from './commands';
 import { setGlobalOptions } from './options';
 import { CustomCommand } from './utils';
 
-// Define the CLI program.
-const program = new CustomCommand();
-program
-  .name('program-metadata')
-  .description('CLI to manage Solana program metadata and IDLs')
-  .version(__VERSION__)
-  .configureHelp({ showGlobalOptions: true })
-  .tap(setGlobalOptions)
-  .tap(setCommands)
-  .parse();
+export async function programMetadata(
+  args: string[],
+  opts?: { suppressOutput?: boolean }
+): Promise<void> {
+  await createProgram({
+    exitOverride: true,
+    suppressOutput: opts?.suppressOutput,
+  }).parseAsync(args, { from: 'user' });
+}
+
+export function createProgram(internalOptions?: {
+  exitOverride?: boolean;
+  suppressOutput?: boolean;
+}): CustomCommand {
+  const program = new CustomCommand();
+  program
+    .name('program-metadata')
+    .description('CLI to manage Solana program metadata and IDLs')
+    .version(__VERSION__)
+    .configureHelp({ showGlobalOptions: true })
+    .tap(setGlobalOptions)
+    .tap(setCommands);
+
+  // Internal options.
+  if (internalOptions?.exitOverride) {
+    program.exitOverride();
+  }
+  if (internalOptions?.suppressOutput) {
+    program.configureOutput({
+      writeErr: () => {},
+      writeOut: () => {},
+    });
+  }
+
+  return program;
+}


### PR DESCRIPTION
The current CLI export works with `pnpx ...` but not `npx ...`. This PR aims to fix this by exporting a static `bin/cli.cjs` executable script that make use of the built CLI instead of using the built files directly.

It also mimics the `createProgram` pattern introduced in the Codama CLI for consistency and better testability in the future.