### PR TITLE
Remove `p-limit` from JS client

### DIFF
--- a/clients/js/package.json
+++ b/clients/js/package.json
@@ -52,7 +52,6 @@
     "@solana-program/compute-budget": "^0.9.0",
     "@solana-program/system": "^0.8.0",
     "commander": "^13.0.0",
-    "p-limit": "^7.1.1",
     "pako": "^2.1.0",
     "picocolors": "^1.1.1",
     "yaml": "^2.7.0"

--- a/clients/js/pnpm-lock.yaml
+++ b/clients/js/pnpm-lock.yaml
@@ -20,9 +20,6 @@ importers:
       commander:
         specifier: ^13.0.0
         version: 13.0.0
-      p-limit:
-        specifier: ^7.1.1
-        version: 7.1.1
       pako:
         specifier: ^2.1.0
         version: 2.1.0
@@ -1557,10 +1554,6 @@ packages:
     resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
     engines: {node: '>=10'}
 
-  p-limit@7.1.1:
-    resolution: {integrity: sha512-i8PyM2JnsNChVSYWLr2BAjNoLi0BAYC+wecOnZnVV+YSNJkzP7cWmvI34dk0WArWfH9KwBHNoZI3P3MppImlIA==}
-    engines: {node: '>=20'}
-
   p-locate@5.0.0:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
     engines: {node: '>=10'}
@@ -2007,10 +2000,6 @@ packages:
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
-
-  yocto-queue@1.2.1:
-    resolution: {integrity: sha512-AyeEbWOu/TAXdxlV9wmGcR0+yh2j3vYPGOECcIj2S7MkrLyC7ne+oye2BKTItt0ii2PHk4cDy+95+LshzbXnGg==}
-    engines: {node: '>=12.20'}
 
 snapshots:
 
@@ -3562,10 +3551,6 @@ snapshots:
     dependencies:
       yocto-queue: 0.1.0
 
-  p-limit@7.1.1:
-    dependencies:
-      yocto-queue: 1.2.1
-
   p-locate@5.0.0:
     dependencies:
       p-limit: 3.1.0
@@ -3956,5 +3941,3 @@ snapshots:
       yargs-parser: 21.1.1
 
   yocto-queue@0.1.0: {}
-
-  yocto-queue@1.2.1: {}


### PR DESCRIPTION
This PR removes the `p-limit` dependency from the JS client and replaces it with a simple homemade solution. This is because `p-limit` is ESM only and will not work on the CLI when using Node v20 or lower.