### PR TITLE
CLI: Log per-instruction details when using --export

### DIFF
--- a/clients/js/src/cli/utils.ts
+++ b/clients/js/src/cli/utils.ts
@@ -121,11 +121,12 @@ async function exportTransactionPlan(
             m => setTransactionMessageLifetimeUsingBlockhash(latestBlockhash, m),
             m => removeComputeUnitLimitInstruction(m),
         );
-        logInstructions(message);
         const transaction = compileTransaction(message);
         const encodedTransaction = decodeData(transactionEncoder.encode(transaction), options.exportEncoding);
         const prefix = picocolors.yellow(`[Transaction #${i + 1}]`);
-        console.log(`${prefix}\n${encodedTransaction}\n`);
+        console.log(`\n${prefix}`);
+        logInstructions(message);
+        console.log(`${picocolors.yellow('Encoded:')}\n${encodedTransaction}\n`);
     }
 }
 

--- a/clients/js/src/cli/utils.ts
+++ b/clients/js/src/cli/utils.ts
@@ -4,6 +4,7 @@ import path from 'path';
 
 import {
     Account,
+    AccountRole,
     Address,
     address,
     Commitment,
@@ -32,7 +33,7 @@ import {
 import { Command } from 'commander';
 import picocolors from 'picocolors';
 import { parse as parseYaml } from 'yaml';
-import { Buffer, DataSource, fetchBuffer, Format, Seed } from '../generated';
+import { Buffer, DataSource, Encoding, fetchBuffer, Format, Seed } from '../generated';
 import { createDefaultTransactionPlannerAndExecutor, getPdaDetails, PdaDetails } from '../internals';
 import { decodeData, packDirectData, PackedData, packExternalData, packUrlData } from '../packData';
 import { logErrorAndExit, logExports, logSuccess, logWarning } from './logs';
@@ -115,16 +116,40 @@ async function exportTransactionPlan(
     const { value: latestBlockhash } = await client.rpc.getLatestBlockhash().send();
 
     for (let i = 0; i < singleTransactions.length; i++) {
-        const transaction = pipe(
+        const message = pipe(
             singleTransactions[i].message,
             m => setTransactionMessageLifetimeUsingBlockhash(latestBlockhash, m),
             m => removeComputeUnitLimitInstruction(m),
-            compileTransaction,
         );
+        logInstructions(message);
+        const transaction = compileTransaction(message);
         const encodedTransaction = decodeData(transactionEncoder.encode(transaction), options.exportEncoding);
         const prefix = picocolors.yellow(`[Transaction #${i + 1}]`);
         console.log(`${prefix}\n${encodedTransaction}\n`);
     }
+}
+
+function logInstructions(message: TransactionMessage): void {
+    message.instructions.forEach((ix, i) => {
+        console.log(picocolors.cyan(`\n------ IX #${i + 1} ------\n`));
+        console.log(`${ix.programAddress}\n`);
+
+        (ix.accounts ?? []).forEach(account => {
+            const isWritable =
+                account.role === AccountRole.WRITABLE || account.role === AccountRole.WRITABLE_SIGNER;
+            const isSigner =
+                account.role === AccountRole.READONLY_SIGNER || account.role === AccountRole.WRITABLE_SIGNER;
+            const writable = isWritable ? 'W' : '';
+            const signer = isSigner ? 'S' : '';
+            console.log(`${String(account.address).padEnd(44)} ${writable.padStart(2)} ${signer.padStart(1)}`);
+        });
+
+        console.log('');
+
+        if (ix.data && ix.data.length > 0) {
+            console.log(`${decodeData(ix.data, Encoding.Base58)}\n`);
+        }
+    });
 }
 
 function removeComputeUnitLimitInstruction<


### PR DESCRIPTION
Summary

- Added `logInstructions` helper to `clients/js/src/cli/utils.ts` that prints a breakdown of each instruction in a transaction when `--export` is used
- Each instruction shows: program address, accounts with writable (`W`) and signer (`S`) flags, and base58-encoded instruction data
- Refactored `exportTransactionPlan` to split the `pipe` into two steps so the pre-compiled message is accessible before `compileTransaction`

## Example output

```
> [Transaction #1]
>
> ------ IX #1 ------
> ComputeBudget111...
>
> ------ IX #2 ------
> ProgM6...
>
> Encoded:
> <base58>
> 
```