### PR TITLE
program: Bump program version to v1.0.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5533,7 +5533,7 @@ dependencies = [
 
 [[package]]
 name = "spl-program-metadata"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "mollusk-svm",
  "pinocchio",

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spl-program-metadata"
-version = "1.0.0"
+version = "1.0.1"
 edition = "2021"
 readme = "./README.md"
 license-file = "../LICENSE"


### PR DESCRIPTION
### Problem

The program has been updated to `v1.0.1` but the version of Cargo.toml still references the previous version.

### Solution

Update the program version.