### PR TITLE
CLI: Add `--export-encoding instruction-list` mode

### DIFF
--- a/clients/js/src/cli/logs.ts
+++ b/clients/js/src/cli/logs.ts
@@ -4,6 +4,7 @@ import { Transform } from 'node:stream';
 
 import picocolors from 'picocolors';
 import { Encoding } from '../generated';
+import type { ExportEncoding } from './options';
 
 export function logCommand(message: string, data: Record<string, string | undefined> = {}): void {
     console.log('');
@@ -24,17 +25,22 @@ export function logCommand(message: string, data: Record<string, string | undefi
 
 export function logExports(
     transactionLength: number,
-    options: { export: Address | boolean; exportEncoding: Encoding },
+    options: { export: Address | boolean; exportEncoding: ExportEncoding },
 ): void {
     const transactionPluralized = transactionLength === 1 ? 'transaction' : 'transactions';
     const forAuthority = typeof options.export === 'string' ? ` for ${picocolors.bold(options.export)}` : '';
-    const encodingName = {
-        [Encoding.None]: 'hexadecimal',
-        [Encoding.Utf8]: 'UTF-8',
-        [Encoding.Base58]: 'Base58',
-        [Encoding.Base64]: 'Base64',
-    }[options.exportEncoding];
-    const message = `Exporting ${transactionLength} ${transactionPluralized}${forAuthority} in ${encodingName}:\n`;
+    const suffix =
+        options.exportEncoding === 'instruction-list'
+            ? 'as an instruction list'
+            : `in ${
+                  {
+                      [Encoding.None]: 'hexadecimal',
+                      [Encoding.Utf8]: 'UTF-8',
+                      [Encoding.Base58]: 'Base58',
+                      [Encoding.Base64]: 'Base64',
+                  }[options.exportEncoding]
+              }`;
+    const message = `Exporting ${transactionLength} ${transactionPluralized}${forAuthority} ${suffix}:\n`;
     console.log(picocolors.yellow(message));
 }
 

--- a/clients/js/src/cli/options.ts
+++ b/clients/js/src/cli/options.ts
@@ -53,14 +53,17 @@ export const exportOption = new Option(
     .default(false)
     .argParser(addressOrBooleanParser('export'));
 
-export type ExportEncodingOption = { exportEncoding: Encoding };
+export type ExportEncoding = Encoding | 'instruction-list';
+export type ExportEncodingOption = { exportEncoding: ExportEncoding };
 export const exportEncodingOption = new Option(
     '--export-encoding <encoding>',
-    'Describes how to encode exported transactions.',
+    'Describes how to encode exported transactions. Use "instruction-list" to print a human-readable list of instructions instead of the raw transaction bytes.',
 )
-    .choices(['none', 'utf8', 'base58', 'base64'])
+    .choices(['none', 'utf8', 'base58', 'base64', 'instruction-list'])
     .default(Encoding.Base64, 'base64')
-    .argParser(encodingParser);
+    .argParser(
+        (value: string): ExportEncoding => (value === 'instruction-list' ? 'instruction-list' : encodingParser(value)),
+    );
 
 export type WriteOptions = TextOption &
     UrlOption &

--- a/clients/js/src/cli/utils.ts
+++ b/clients/js/src/cli/utils.ts
@@ -121,11 +121,12 @@ async function exportTransactionPlan(
             m => setTransactionMessageLifetimeUsingBlockhash(latestBlockhash, m),
             m => removeComputeUnitLimitInstruction(m),
         );
-        logInstructions(message);
         const transaction = compileTransaction(message);
         const encodedTransaction = decodeData(transactionEncoder.encode(transaction), options.exportEncoding);
         const prefix = picocolors.yellow(`[Transaction #${i + 1}]`);
-        console.log(`${prefix}\n${encodedTransaction}\n`);
+        console.log(`\n${prefix}`);
+        logInstructions(message);
+        console.log(`${picocolors.yellow('Encoded:')}\n${encodedTransaction}\n`);
     }
 }
 

--- a/clients/js/src/cli/utils.ts
+++ b/clients/js/src/cli/utils.ts
@@ -121,12 +121,15 @@ async function exportTransactionPlan(
             m => setTransactionMessageLifetimeUsingBlockhash(latestBlockhash, m),
             m => removeComputeUnitLimitInstruction(m),
         );
-        const transaction = compileTransaction(message);
-        const encodedTransaction = decodeData(transactionEncoder.encode(transaction), options.exportEncoding);
         const prefix = picocolors.yellow(`[Transaction #${i + 1}]`);
-        console.log(`\n${prefix}`);
-        logInstructions(message);
-        console.log(`${picocolors.yellow('Encoded:')}\n${encodedTransaction}\n`);
+        if (options.exportEncoding === 'instruction-list') {
+            console.log(`\n${prefix}`);
+            logInstructions(message);
+        } else {
+            const transaction = compileTransaction(message);
+            const encodedTransaction = decodeData(transactionEncoder.encode(transaction), options.exportEncoding);
+            console.log(`${prefix}\n${encodedTransaction}\n`);
+        }
     }
 }
 
@@ -136,8 +139,7 @@ function logInstructions(message: TransactionMessage): void {
         console.log(`${ix.programAddress}\n`);
 
         (ix.accounts ?? []).forEach(account => {
-            const isWritable =
-                account.role === AccountRole.WRITABLE || account.role === AccountRole.WRITABLE_SIGNER;
+            const isWritable = account.role === AccountRole.WRITABLE || account.role === AccountRole.WRITABLE_SIGNER;
             const isSigner =
                 account.role === AccountRole.READONLY_SIGNER || account.role === AccountRole.WRITABLE_SIGNER;
             const writable = isWritable ? 'W' : '';

--- a/clients/js/src/cli/utils.ts
+++ b/clients/js/src/cli/utils.ts
@@ -4,6 +4,7 @@ import path from 'path';
 
 import {
     Account,
+    AccountRole,
     Address,
     address,
     Commitment,
@@ -32,7 +33,7 @@ import {
 import { Command } from 'commander';
 import picocolors from 'picocolors';
 import { parse as parseYaml } from 'yaml';
-import { Buffer, DataSource, fetchBuffer, Format, Seed } from '../generated';
+import { Buffer, DataSource, Encoding, fetchBuffer, Format, Seed } from '../generated';
 import { createDefaultTransactionPlannerAndExecutor, getPdaDetails, PdaDetails } from '../internals';
 import { decodeData, packDirectData, PackedData, packExternalData, packUrlData } from '../packData';
 import { logErrorAndExit, logExports, logSuccess, logWarning } from './logs';
@@ -115,16 +116,40 @@ async function exportTransactionPlan(
     const { value: latestBlockhash } = await client.rpc.getLatestBlockhash().send();
 
     for (let i = 0; i < singleTransactions.length; i++) {
-        const transaction = pipe(
+        const message = pipe(
             singleTransactions[i].message,
             m => setTransactionMessageLifetimeUsingBlockhash(latestBlockhash, m),
             m => removeComputeUnitLimitInstruction(m),
-            compileTransaction,
         );
+        logInstructions(message);
+        const transaction = compileTransaction(message);
         const encodedTransaction = decodeData(transactionEncoder.encode(transaction), options.exportEncoding);
         const prefix = picocolors.yellow(`[Transaction #${i + 1}]`);
         console.log(`${prefix}\n${encodedTransaction}\n`);
     }
+}
+
+function logInstructions(message: TransactionMessage): void {
+    message.instructions.forEach((ix, i) => {
+        console.log(picocolors.cyan(`\n------ IX #${i + 1} ------\n`));
+        console.log(`${ix.programAddress}\n`);
+
+        (ix.accounts ?? []).forEach(account => {
+            const isWritable =
+                account.role === AccountRole.WRITABLE || account.role === AccountRole.WRITABLE_SIGNER;
+            const isSigner =
+                account.role === AccountRole.READONLY_SIGNER || account.role === AccountRole.WRITABLE_SIGNER;
+            const writable = isWritable ? 'W' : '';
+            const signer = isSigner ? 'S' : '';
+            console.log(`${String(account.address).padEnd(44)} ${writable.padStart(2)} ${signer.padStart(1)}`);
+        });
+
+        console.log('');
+
+        if (ix.data && ix.data.length > 0) {
+            console.log(`${decodeData(ix.data, Encoding.Base58)}\n`);
+        }
+    });
 }
 
 function removeComputeUnitLimitInstruction<


### PR DESCRIPTION
## Summary

- Adds `instruction-list` as a new value for the `--export-encoding` CLI option, alongside the existing `none|utf8|base58|base64` choices.
- When selected, the CLI prints a human-readable view of each transaction (program address, accounts with writable/signer flags, and base58-encoded instruction data) instead of the raw encoded transaction bytes.
- Default behavior is unchanged: without `--export-encoding instruction-list`, output remains exactly the raw encoded transaction so downstream tooling that consumes the bytes is not affected.

## Motivation

Per review feedback, the instruction-list view is useful for humans inspecting what a `--export`ed transaction will do, but it pollutes output for users who only need the raw transaction bytes (e.g. piping into another tool). Making it a separate export mode lets each use case stay clean.

## Changes

- `clients/js/src/cli/options.ts`: introduce `ExportEncoding = Encoding | 'instruction-list'`, add `instruction-list` to `--export-encoding` choices, and update the parser.
- `clients/js/src/cli/utils.ts`: branch in `exportTransactionPlan` — print the instruction list when `instruction-list` is selected, otherwise print only the encoded transaction (no instruction list).
- `clients/js/src/cli/logs.ts`: `logExports` accepts the new `ExportEncoding` type and renders `"... as an instruction list"` vs. `"... in <encoding>"`.


```bash
node bin/cli.cjs write \
    idl ... \
    --buffer ... \
    --export ... \
    --export-encoding instruction-list \
    --close-buffer ...
```