### PR TITLE
Include program metadata command in LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-                                 Apache License
+npx @solana-program/program-metadata@latest write <seed> <program-id> <file> [options]                                 Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/
 


### PR DESCRIPTION
Added command for writing program metadata to the LICENSE file.npx @solana-program/program-metadata@latest write <seed> <program-id> <file> [options]