### PR TITLE
program: Improve program tests

### DIFF
--- a/program/src/instruction.rs
+++ b/program/src/instruction.rs
@@ -82,8 +82,8 @@ pub enum ProgramMetadataInstruction {
     ///
     ///  0. `[w]` Buffer or metadata account.
     ///  1. `[s]` Current authority account.
-    ///  2. `[o]` (optional) Program account.
-    ///  3. `[o]` (optional) Program data account.
+    ///  2. `[o]` Program account.
+    ///  3. `[o]` Program data account.
     ///
     /// Instruction data:
     ///
@@ -111,9 +111,9 @@ pub enum ProgramMetadataInstruction {
     ///
     ///  0. `[w]` Metadata account.
     ///  1. `[s]` Authority account.
-    ///  2. `[o]` (optional) Buffer account to copy data from.
-    ///  3. `[o]` (optional) Program account.
-    ///  4. `[o]` (optional) Program data account.
+    ///  2. `[o]` Buffer account to copy data from.
+    ///  3. `[o]` Program account.
+    ///  4. `[o]` Program data account.
     ///
     /// Instruction data:
     ///
@@ -136,8 +136,8 @@ pub enum ProgramMetadataInstruction {
     ///
     ///  0. `[w]` Metadata account.
     ///  1. `[s]` Authority account.
-    ///  2. `[o]` (optional) Program account.
-    ///  3. `[o]` (optional) Program data account.
+    ///  2. `[o]` Program account.
+    ///  3. `[o]` Program data account.
     SetImmutable,
 
     /// Resizes and withdraws excess lamports from a buffer or metadata account.
@@ -156,8 +156,8 @@ pub enum ProgramMetadataInstruction {
     ///
     ///  0. `[w]` Buffer or metadata account.
     ///  1. `[s]` Authority account.
-    ///  2. `[o]` (optional) Program account.
-    ///  3. `[o]` (optional) Program data account.
+    ///  2. `[o]` Program account.
+    ///  3. `[o]` Program data account.
     ///  5. `[w]` Destination account.
     ///  6. `[]` Rent sysvar account.
     Trim,
@@ -180,8 +180,8 @@ pub enum ProgramMetadataInstruction {
     ///
     ///  0. `[w]` Account to close.
     ///  1. `[s]` Metadata authority or buffer account.
-    ///  2. `[o]` (optional) Program account.
-    ///  3. `[o]` (optional) Program data account.
+    ///  2. `[o]` Program account.
+    ///  3. `[o]` Program data account.
     ///  5. `[w]` Destination account.
     Close,
 
@@ -233,8 +233,8 @@ pub enum ProgramMetadataInstruction {
     ///
     ///  0. `[w]` Buffer or metadata account.
     ///  1. `[s]` Authority account.
-    ///  2. `[o]` (optional) Program account.
-    ///  3. `[o]` (optional) Program data account.
+    ///  2. `[o]` Program account.
+    ///  3. `[o]` Program data account.
     ///
     /// Instruction data:
     ///

--- a/program/src/processor/set_data.rs
+++ b/program/src/processor/set_data.rs
@@ -86,7 +86,10 @@ pub fn set_data(accounts: &mut [AccountView], instruction_data: &[u8]) -> Progra
 
     // Update header and data (if needed).
 
-    if let Some(data) = update_header(metadata, args, data)? {
+    if let Some(data) = update_header(metadata, args, data).map_err(|err| match err {
+        ProgramError::InvalidAccountData => ProgramError::InvalidInstructionData,
+        _ => err,
+    })? {
         // Realloc the metadata account if necessary.
 
         // SAFETY: There are no other active borrows to the `metadata` account data.

--- a/program/tests/allocate.rs
+++ b/program/tests/allocate.rs
@@ -6,7 +6,10 @@ use solana_account::Account;
 use solana_program_error::ProgramError;
 use solana_pubkey::Pubkey;
 use solana_sdk_ids::system_program;
-use spl_program_metadata::state::{buffer::Buffer, SEED_LEN};
+use spl_program_metadata::{
+    error::ProgramMetadataError,
+    state::{buffer::Buffer, SEED_LEN},
+};
 
 #[test]
 fn test_allocate_canonical() {
@@ -413,6 +416,137 @@ fn test_allocate_with_unfunded_account() {
             &allocate(&buffer_key, &buffer_key, None, None, None).unwrap(),
             &[Check::err(ProgramError::AccountNotRentExempt)],
         ),
+        &[
+            (buffer_key, buffer_account),
+            (PROGRAM_ID, Account::default()),
+            keyed_account_for_system_program(),
+        ],
+    );
+}
+
+#[test]
+fn fail_allocate_keypair_with_seed() {
+    let buffer_key = Pubkey::new_unique();
+    let buffer_account =
+        create_funded_account(minimum_balance_for(Buffer::LEN), system_program::ID);
+
+    let mut seed = [0u8; SEED_LEN];
+    seed[0..3].copy_from_slice("idl".as_bytes());
+
+    process_instruction(
+        (
+            &allocate(&buffer_key, &buffer_key, None, None, Some(&seed)).unwrap(),
+            &[Check::err(ProgramError::InvalidInstructionData)],
+        ),
+        &[
+            (buffer_key, buffer_account),
+            (PROGRAM_ID, Account::default()),
+            keyed_account_for_system_program(),
+        ],
+    );
+}
+
+#[test]
+fn fail_allocate_pda_with_wrong_seed() {
+    let authority_key = Pubkey::new_unique();
+
+    let program_data_key = Pubkey::new_unique();
+    let program_data_account = setup_program_data_account(Some(&authority_key));
+
+    let program_key = Pubkey::new_unique();
+    let program_account = setup_program_account(&program_data_key);
+
+    let mut seed = [0u8; SEED_LEN];
+    seed[0..3].copy_from_slice("idl".as_bytes());
+
+    let mut wrong_seed = [0u8; SEED_LEN];
+    wrong_seed[0..5].copy_from_slice("other".as_bytes());
+
+    let (buffer_key, _) = Pubkey::find_program_address(&[program_key.as_ref(), &seed], &PROGRAM_ID);
+    let buffer_account = create_empty_account(Buffer::LEN, PROGRAM_ID);
+
+    process_instruction(
+        (
+            &allocate(
+                &buffer_key,
+                &authority_key,
+                Some(&program_key),
+                Some(&program_data_key),
+                Some(&wrong_seed),
+            )
+            .unwrap(),
+            &[Check::err(ProgramError::InvalidSeeds)],
+        ),
+        &[
+            (buffer_key, buffer_account),
+            (authority_key, Account::default()),
+            (program_key, program_account),
+            (program_data_key, program_data_account),
+            keyed_account_for_system_program(),
+        ],
+    );
+}
+
+#[test]
+fn fail_allocate_pda_for_non_executable_program() {
+    let authority_key = Pubkey::new_unique();
+
+    let program_data_key = Pubkey::new_unique();
+    let program_data_account = setup_program_data_account(Some(&authority_key));
+
+    let program_key = Pubkey::new_unique();
+    let program_account = Account::default();
+
+    let mut seed = [0u8; SEED_LEN];
+    seed[0..3].copy_from_slice("idl".as_bytes());
+
+    let (buffer_key, _) = Pubkey::find_program_address(
+        &[program_key.as_ref(), authority_key.as_ref(), &seed],
+        &PROGRAM_ID,
+    );
+    let buffer_account = create_empty_account(Buffer::LEN, PROGRAM_ID);
+
+    process_instruction(
+        (
+            &allocate(
+                &buffer_key,
+                &authority_key,
+                Some(&program_key),
+                Some(&program_data_key),
+                Some(&seed),
+            )
+            .unwrap(),
+            &[Check::err(ProgramError::Custom(
+                ProgramMetadataError::NotExecutableAccount as u32,
+            ))],
+        ),
+        &[
+            (buffer_key, buffer_account),
+            (authority_key, Account::default()),
+            (program_key, program_account),
+            (program_data_key, program_data_account),
+            keyed_account_for_system_program(),
+        ],
+    );
+}
+
+#[test]
+fn fail_allocate_already_initialized_buffer() {
+    let buffer_key = Pubkey::new_unique();
+    let buffer_account =
+        create_funded_account(minimum_balance_for(Buffer::LEN), system_program::ID);
+
+    process_instructions(
+        &[
+            (
+                &allocate(&buffer_key, &buffer_key, None, None, None).unwrap(),
+                &[Check::success()],
+            ),
+            (
+                &allocate(&buffer_key, &buffer_key, None, None, None).unwrap(),
+                &[Check::err(ProgramError::AccountAlreadyInitialized)],
+            ),
+        ],
         &[
             (buffer_key, buffer_account),
             (PROGRAM_ID, Account::default()),

--- a/program/tests/allocate.rs
+++ b/program/tests/allocate.rs
@@ -36,8 +36,7 @@ fn test_allocate_canonical() {
                 Some(&program_key),
                 Some(&program_data_key),
                 Some(&seed),
-            )
-            .unwrap(),
+            ),
             &[
                 Check::success(),
                 // data lenght
@@ -84,8 +83,7 @@ fn test_allocate_non_canonical() {
                 Some(&program_key),
                 Some(&program_data_key),
                 Some(&seed),
-            )
-            .unwrap(),
+            ),
             &[
                 Check::success(),
                 // data lenght
@@ -113,7 +111,7 @@ fn test_allocate_keypair() {
 
     process_instruction(
         (
-            &allocate(&buffer_key, &buffer_key, None, None, None).unwrap(),
+            &allocate(&buffer_key, &buffer_key, None, None, None),
             &[
                 Check::success(),
                 // data lenght
@@ -139,7 +137,7 @@ fn test_allocate_with_empty_account() {
 
     process_instruction(
         (
-            &allocate(&buffer_key, &buffer_key, None, None, None).unwrap(),
+            &allocate(&buffer_key, &buffer_key, None, None, None),
             &[
                 Check::success(),
                 // data lenght
@@ -165,7 +163,7 @@ fn test_allocate_with_unsufficient_length() {
 
     process_instruction(
         (
-            &allocate(&buffer_key, &buffer_key, None, None, None).unwrap(),
+            &allocate(&buffer_key, &buffer_key, None, None, None),
             &[Check::err(ProgramError::InvalidAccountData)],
         ),
         &[
@@ -202,8 +200,7 @@ fn test_allocate_with_funded_canonical_account() {
                 Some(&program_key),
                 Some(&program_data_key),
                 Some(&seed),
-            )
-            .unwrap(),
+            ),
             &[
                 Check::success(),
                 // data lenght
@@ -251,8 +248,7 @@ fn test_allocate_with_funded_non_canonical_account() {
                 Some(&program_key),
                 Some(&program_data_key),
                 Some(&seed),
-            )
-            .unwrap(),
+            ),
             &[
                 Check::success(),
                 // data lenght
@@ -280,7 +276,7 @@ fn test_allocate_with_funded_keypair_account() {
 
     process_instruction(
         (
-            &allocate(&buffer_key, &buffer_key, None, None, None).unwrap(),
+            &allocate(&buffer_key, &buffer_key, None, None, None),
             &[
                 Check::success(),
                 // data lenght
@@ -306,7 +302,7 @@ fn test_allocate_with_allocated_keypair_account() {
 
     process_instruction(
         (
-            &allocate(&buffer_key, &buffer_key, None, None, None).unwrap(),
+            &allocate(&buffer_key, &buffer_key, None, None, None),
             &[
                 Check::success(),
                 // account owner
@@ -348,8 +344,7 @@ fn test_allocate_with_unfunded_canonical_account() {
                 Some(&program_key),
                 Some(&program_data_key),
                 Some(&seed),
-            )
-            .unwrap(),
+            ),
             &[Check::err(ProgramError::AccountNotRentExempt)],
         ),
         &[
@@ -390,8 +385,7 @@ fn test_allocate_with_unfunded_non_canonical_account() {
                 Some(&program_key),
                 Some(&program_data_key),
                 Some(&seed),
-            )
-            .unwrap(),
+            ),
             &[Check::err(ProgramError::AccountNotRentExempt)],
         ),
         &[
@@ -413,7 +407,7 @@ fn test_allocate_with_unfunded_account() {
 
     process_instruction(
         (
-            &allocate(&buffer_key, &buffer_key, None, None, None).unwrap(),
+            &allocate(&buffer_key, &buffer_key, None, None, None),
             &[Check::err(ProgramError::AccountNotRentExempt)],
         ),
         &[
@@ -435,7 +429,7 @@ fn fail_allocate_keypair_with_seed() {
 
     process_instruction(
         (
-            &allocate(&buffer_key, &buffer_key, None, None, Some(&seed)).unwrap(),
+            &allocate(&buffer_key, &buffer_key, None, None, Some(&seed)),
             &[Check::err(ProgramError::InvalidInstructionData)],
         ),
         &[
@@ -473,8 +467,7 @@ fn fail_allocate_pda_with_wrong_seed() {
                 Some(&program_key),
                 Some(&program_data_key),
                 Some(&wrong_seed),
-            )
-            .unwrap(),
+            ),
             &[Check::err(ProgramError::InvalidSeeds)],
         ),
         &[
@@ -514,8 +507,7 @@ fn fail_allocate_pda_for_non_executable_program() {
                 Some(&program_key),
                 Some(&program_data_key),
                 Some(&seed),
-            )
-            .unwrap(),
+            ),
             &[Check::err(ProgramError::Custom(
                 ProgramMetadataError::NotExecutableAccount as u32,
             ))],
@@ -539,11 +531,11 @@ fn fail_allocate_already_initialized_buffer() {
     process_instructions(
         &[
             (
-                &allocate(&buffer_key, &buffer_key, None, None, None).unwrap(),
+                &allocate(&buffer_key, &buffer_key, None, None, None),
                 &[Check::success()],
             ),
             (
-                &allocate(&buffer_key, &buffer_key, None, None, None).unwrap(),
+                &allocate(&buffer_key, &buffer_key, None, None, None),
                 &[Check::err(ProgramError::AccountAlreadyInitialized)],
             ),
         ],

--- a/program/tests/close.rs
+++ b/program/tests/close.rs
@@ -1,0 +1,282 @@
+mod setup;
+pub use setup::*;
+
+use mollusk_svm::{program::keyed_account_for_system_program, result::Check};
+use solana_account::Account;
+use solana_program_error::ProgramError;
+use solana_pubkey::Pubkey;
+use solana_sdk_ids::system_program;
+use spl_program_metadata::{
+    error::ProgramMetadataError,
+    state::{buffer::Buffer, header::Header, SEED_LEN},
+};
+
+#[test]
+fn test_close_metadata() {
+    let authority_key = Pubkey::new_unique();
+
+    let program_data_key = Pubkey::new_unique();
+    let program_data_account = setup_program_data_account(Some(&authority_key));
+
+    let program_key = Pubkey::new_unique();
+    let program_account = setup_program_account(&program_data_key);
+
+    let mut seed = [0u8; SEED_LEN];
+    seed[0..3].copy_from_slice("idl".as_bytes());
+
+    let (metadata_key, _) =
+        Pubkey::find_program_address(&[program_key.as_ref(), &seed], &PROGRAM_ID);
+
+    let data = [1u8; 7];
+    let metadata_lamports = minimum_balance_for(Header::LEN + data.len());
+    let metadata_account = create_funded_account(metadata_lamports, system_program::ID);
+
+    let destination_key = Pubkey::new_unique();
+
+    process_instructions(
+        &[
+            (
+                &initialize(
+                    &authority_key,
+                    &program_key,
+                    Some(&program_data_key),
+                    InitializeArgs {
+                        canonical: true,
+                        seed,
+                        encoding: 0,
+                        compression: 0,
+                        format: 0,
+                        data_source: 0,
+                    },
+                    Some(&data),
+                )
+                .unwrap(),
+                &[
+                    Check::success(),
+                    // account discriminator
+                    Check::account(&metadata_key).data_slice(0, &[2]).build(),
+                ],
+            ),
+            (
+                &close(
+                    &metadata_key,
+                    &authority_key,
+                    Some(&program_key),
+                    Some(&program_data_key),
+                    &destination_key,
+                )
+                .unwrap(),
+                &[
+                    Check::success(),
+                    // metadata account
+                    Check::account(&metadata_key).closed().build(),
+                    // destination lamports
+                    Check::account(&destination_key)
+                        .lamports(metadata_lamports)
+                        .build(),
+                ],
+            ),
+        ],
+        &[
+            (metadata_key, metadata_account),
+            (PROGRAM_ID, Account::default()),
+            (authority_key, Account::default()),
+            (program_key, program_account),
+            (program_data_key, program_data_account),
+            (destination_key, Account::default()),
+            keyed_account_for_system_program(),
+        ],
+    );
+}
+
+#[test]
+fn test_close_buffer() {
+    let buffer_key = Pubkey::new_unique();
+    let buffer_lamports = minimum_balance_for(Buffer::LEN);
+    let buffer_account = create_funded_account(buffer_lamports, system_program::ID);
+
+    let destination_key = Pubkey::new_unique();
+
+    process_instructions(
+        &[
+            (
+                &allocate(&buffer_key, &buffer_key, None, None, None).unwrap(),
+                &[
+                    Check::success(),
+                    // account discriminator
+                    Check::account(&buffer_key).data_slice(0, &[1]).build(),
+                ],
+            ),
+            (
+                &close(&buffer_key, &buffer_key, None, None, &destination_key).unwrap(),
+                &[
+                    Check::success(),
+                    // buffer account
+                    Check::account(&buffer_key).closed().build(),
+                    // destination lamports
+                    Check::account(&destination_key)
+                        .lamports(buffer_lamports)
+                        .build(),
+                ],
+            ),
+        ],
+        &[
+            (buffer_key, buffer_account),
+            (PROGRAM_ID, Account::default()),
+            (destination_key, Account::default()),
+            keyed_account_for_system_program(),
+        ],
+    );
+}
+
+#[test]
+fn fail_close_with_wrong_authority() {
+    let buffer_key = Pubkey::new_unique();
+    let wrong_authority_key = Pubkey::new_unique();
+    let buffer_lamports = minimum_balance_for(Buffer::LEN);
+    let buffer_account = create_funded_account(buffer_lamports, system_program::ID);
+
+    let destination_key = Pubkey::new_unique();
+
+    process_instructions(
+        &[
+            (
+                &allocate(&buffer_key, &buffer_key, None, None, None).unwrap(),
+                &[Check::success()],
+            ),
+            (
+                &close(
+                    &buffer_key,
+                    &wrong_authority_key,
+                    None,
+                    None,
+                    &destination_key,
+                )
+                .unwrap(),
+                &[Check::err(ProgramError::IncorrectAuthority)],
+            ),
+        ],
+        &[
+            (buffer_key, buffer_account),
+            (PROGRAM_ID, Account::default()),
+            (wrong_authority_key, Account::default()),
+            (destination_key, Account::default()),
+            keyed_account_for_system_program(),
+        ],
+    );
+}
+
+#[test]
+fn fail_close_uninitialized_account() {
+    let account_key = Pubkey::new_unique();
+    let destination_key = Pubkey::new_unique();
+
+    process_instruction(
+        (
+            &close(&account_key, &account_key, None, None, &destination_key).unwrap(),
+            &[Check::err(ProgramError::UninitializedAccount)],
+        ),
+        &[
+            (account_key, Account::default()),
+            (PROGRAM_ID, Account::default()),
+            (destination_key, Account::default()),
+        ],
+    );
+}
+
+#[test]
+fn fail_close_account_with_empty_discriminator() {
+    let account_key = Pubkey::new_unique();
+    let account = create_empty_account(Buffer::LEN, PROGRAM_ID);
+    let destination_key = Pubkey::new_unique();
+
+    process_instruction(
+        (
+            &close(&account_key, &account_key, None, None, &destination_key).unwrap(),
+            &[Check::err(ProgramError::InvalidAccountData)],
+        ),
+        &[
+            (account_key, account),
+            (PROGRAM_ID, Account::default()),
+            (destination_key, Account::default()),
+        ],
+    );
+}
+
+#[test]
+fn fail_close_immutable_metadata() {
+    let authority_key = Pubkey::new_unique();
+
+    let program_data_key = Pubkey::new_unique();
+    let program_data_account = setup_program_data_account(Some(&authority_key));
+
+    let program_key = Pubkey::new_unique();
+    let program_account = setup_program_account(&program_data_key);
+
+    let mut seed = [0u8; SEED_LEN];
+    seed[0..3].copy_from_slice("idl".as_bytes());
+
+    let (metadata_key, _) =
+        Pubkey::find_program_address(&[program_key.as_ref(), &seed], &PROGRAM_ID);
+
+    let data = [1u8; 7];
+    let metadata_lamports = minimum_balance_for(Header::LEN + data.len());
+    let metadata_account = create_funded_account(metadata_lamports, system_program::ID);
+
+    let destination_key = Pubkey::new_unique();
+
+    process_instructions(
+        &[
+            (
+                &initialize(
+                    &authority_key,
+                    &program_key,
+                    Some(&program_data_key),
+                    InitializeArgs {
+                        canonical: true,
+                        seed,
+                        encoding: 0,
+                        compression: 0,
+                        format: 0,
+                        data_source: 0,
+                    },
+                    Some(&data),
+                )
+                .unwrap(),
+                &[Check::success()],
+            ),
+            (
+                &set_immutable(
+                    &metadata_key,
+                    &authority_key,
+                    Some(&program_key),
+                    Some(&program_data_key),
+                )
+                .unwrap(),
+                &[Check::success()],
+            ),
+            (
+                &close(
+                    &metadata_key,
+                    &authority_key,
+                    Some(&program_key),
+                    Some(&program_data_key),
+                    &destination_key,
+                )
+                .unwrap(),
+                &[Check::err(ProgramError::Custom(
+                    ProgramMetadataError::ImmutableMetadataAccount as u32,
+                ))],
+            ),
+        ],
+        &[
+            (metadata_key, metadata_account),
+            (PROGRAM_ID, Account::default()),
+            (authority_key, Account::default()),
+            (program_key, program_account),
+            (program_data_key, program_data_account),
+            (destination_key, Account::default()),
+            keyed_account_for_system_program(),
+        ],
+    );
+}

--- a/program/tests/close.rs
+++ b/program/tests/close.rs
@@ -49,8 +49,7 @@ fn test_close_metadata() {
                         data_source: 0,
                     },
                     Some(&data),
-                )
-                .unwrap(),
+                ),
                 &[
                     Check::success(),
                     // account discriminator
@@ -64,8 +63,7 @@ fn test_close_metadata() {
                     Some(&program_key),
                     Some(&program_data_key),
                     &destination_key,
-                )
-                .unwrap(),
+                ),
                 &[
                     Check::success(),
                     // metadata account
@@ -100,7 +98,7 @@ fn test_close_buffer() {
     process_instructions(
         &[
             (
-                &allocate(&buffer_key, &buffer_key, None, None, None).unwrap(),
+                &allocate(&buffer_key, &buffer_key, None, None, None),
                 &[
                     Check::success(),
                     // account discriminator
@@ -108,7 +106,7 @@ fn test_close_buffer() {
                 ],
             ),
             (
-                &close(&buffer_key, &buffer_key, None, None, &destination_key).unwrap(),
+                &close(&buffer_key, &buffer_key, None, None, &destination_key),
                 &[
                     Check::success(),
                     // buffer account
@@ -141,7 +139,7 @@ fn fail_close_with_wrong_authority() {
     process_instructions(
         &[
             (
-                &allocate(&buffer_key, &buffer_key, None, None, None).unwrap(),
+                &allocate(&buffer_key, &buffer_key, None, None, None),
                 &[Check::success()],
             ),
             (
@@ -151,8 +149,7 @@ fn fail_close_with_wrong_authority() {
                     None,
                     None,
                     &destination_key,
-                )
-                .unwrap(),
+                ),
                 &[Check::err(ProgramError::IncorrectAuthority)],
             ),
         ],
@@ -173,7 +170,7 @@ fn fail_close_uninitialized_account() {
 
     process_instruction(
         (
-            &close(&account_key, &account_key, None, None, &destination_key).unwrap(),
+            &close(&account_key, &account_key, None, None, &destination_key),
             &[Check::err(ProgramError::UninitializedAccount)],
         ),
         &[
@@ -192,7 +189,7 @@ fn fail_close_account_with_empty_discriminator() {
 
     process_instruction(
         (
-            &close(&account_key, &account_key, None, None, &destination_key).unwrap(),
+            &close(&account_key, &account_key, None, None, &destination_key),
             &[Check::err(ProgramError::InvalidAccountData)],
         ),
         &[
@@ -241,8 +238,7 @@ fn fail_close_immutable_metadata() {
                         data_source: 0,
                     },
                     Some(&data),
-                )
-                .unwrap(),
+                ),
                 &[Check::success()],
             ),
             (
@@ -251,8 +247,7 @@ fn fail_close_immutable_metadata() {
                     &authority_key,
                     Some(&program_key),
                     Some(&program_data_key),
-                )
-                .unwrap(),
+                ),
                 &[Check::success()],
             ),
             (
@@ -262,8 +257,7 @@ fn fail_close_immutable_metadata() {
                     Some(&program_key),
                     Some(&program_data_key),
                     &destination_key,
-                )
-                .unwrap(),
+                ),
                 &[Check::err(ProgramError::Custom(
                     ProgramMetadataError::ImmutableMetadataAccount as u32,
                 ))],

--- a/program/tests/extend.rs
+++ b/program/tests/extend.rs
@@ -6,12 +6,12 @@ use solana_account::Account;
 use solana_program_error::ProgramError;
 use solana_pubkey::Pubkey;
 use solana_sdk_ids::system_program;
-use spl_program_metadata::state::{buffer::Buffer, SEED_LEN};
+use spl_program_metadata::state::{buffer::Buffer, header::Header, SEED_LEN};
 
 const EXTEND_LENGTH: usize = 200;
 
 #[test]
-fn test_extend_canonical() {
+fn test_extend_canonical_buffer() {
     let authority_key = Pubkey::new_unique();
 
     let program_data_key = Pubkey::new_unique();
@@ -82,7 +82,7 @@ fn test_extend_canonical() {
 }
 
 #[test]
-fn test_extend_non_canonical() {
+fn test_extend_non_canonical_buffer() {
     let authority_key = Pubkey::new_unique();
 
     let program_data_key = Pubkey::new_unique();
@@ -156,7 +156,7 @@ fn test_extend_non_canonical() {
 }
 
 #[test]
-fn test_extend_buffer() {
+fn test_extend_keypair_buffer() {
     let buffer_key = Pubkey::new_unique();
     let buffer_account = create_funded_account(
         minimum_balance_for(Buffer::LEN + EXTEND_LENGTH),
@@ -193,6 +193,78 @@ fn test_extend_buffer() {
         &[
             (buffer_key, buffer_account),
             (PROGRAM_ID, Account::default()),
+            keyed_account_for_system_program(),
+        ],
+    );
+}
+
+#[test]
+fn test_extend_metadata() {
+    let authority_key = Pubkey::new_unique();
+
+    let program_data_key = Pubkey::new_unique();
+    let program_data_account = setup_program_data_account(Some(&authority_key));
+
+    let program_key = Pubkey::new_unique();
+    let program_account = setup_program_account(&program_data_key);
+
+    let mut seed = [0u8; SEED_LEN];
+    seed[0..3].copy_from_slice("idl".as_bytes());
+
+    let (metadata_key, _) =
+        Pubkey::find_program_address(&[program_key.as_ref(), &seed], &PROGRAM_ID);
+    let data = [1u8; 8];
+    let metadata_account = create_funded_account(
+        minimum_balance_for(Header::LEN + data.len() + EXTEND_LENGTH),
+        system_program::ID,
+    );
+
+    process_instructions(
+        &[
+            (
+                &initialize(
+                    &authority_key,
+                    &program_key,
+                    Some(&program_data_key),
+                    InitializeArgs {
+                        canonical: true,
+                        seed,
+                        encoding: 0,
+                        compression: 0,
+                        format: 0,
+                        data_source: 0,
+                    },
+                    Some(&data),
+                )
+                .unwrap(),
+                &[Check::success()],
+            ),
+            (
+                &extend(
+                    &metadata_key,
+                    &authority_key,
+                    Some(&program_key),
+                    Some(&program_data_key),
+                    EXTEND_LENGTH as u16,
+                )
+                .unwrap(),
+                &[
+                    Check::success(),
+                    Check::account(&metadata_key)
+                        .space(Header::LEN + data.len() + EXTEND_LENGTH)
+                        .build(),
+                    Check::account(&metadata_key)
+                        .data_slice(Header::LEN, &data)
+                        .build(),
+                ],
+            ),
+        ],
+        &[
+            (metadata_key, metadata_account),
+            (PROGRAM_ID, Account::default()),
+            (authority_key, Account::default()),
+            (program_key, program_account),
+            (program_data_key, program_data_account),
             keyed_account_for_system_program(),
         ],
     );

--- a/program/tests/extend.rs
+++ b/program/tests/extend.rs
@@ -39,8 +39,7 @@ fn test_extend_canonical_buffer() {
                     Some(&program_key),
                     Some(&program_data_key),
                     Some(&seed),
-                )
-                .unwrap(),
+                ),
                 &[
                     Check::success(),
                     // account discriminator
@@ -56,8 +55,7 @@ fn test_extend_canonical_buffer() {
                     Some(&program_key),
                     Some(&program_data_key),
                     EXTEND_LENGTH as u16,
-                )
-                .unwrap(),
+                ),
                 &[
                     Check::success(),
                     // data lenght
@@ -113,8 +111,7 @@ fn test_extend_non_canonical_buffer() {
                     Some(&program_key),
                     Some(&program_data_key),
                     Some(&seed),
-                )
-                .unwrap(),
+                ),
                 &[
                     Check::success(),
                     // data lenght
@@ -130,8 +127,7 @@ fn test_extend_non_canonical_buffer() {
                     Some(&program_key),
                     Some(&program_data_key),
                     EXTEND_LENGTH as u16,
-                )
-                .unwrap(),
+                ),
                 &[
                     Check::success(),
                     // data lenght
@@ -166,7 +162,7 @@ fn test_extend_keypair_buffer() {
     process_instructions(
         &[
             (
-                &allocate(&buffer_key, &buffer_key, None, None, None).unwrap(),
+                &allocate(&buffer_key, &buffer_key, None, None, None),
                 &[
                     Check::success(),
                     // data lenght
@@ -176,7 +172,7 @@ fn test_extend_keypair_buffer() {
                 ],
             ),
             (
-                &extend(&buffer_key, &buffer_key, None, None, EXTEND_LENGTH as u16).unwrap(),
+                &extend(&buffer_key, &buffer_key, None, None, EXTEND_LENGTH as u16),
                 &[
                     Check::success(),
                     // data lenght
@@ -235,8 +231,7 @@ fn test_extend_metadata() {
                         data_source: 0,
                     },
                     Some(&data),
-                )
-                .unwrap(),
+                ),
                 &[Check::success()],
             ),
             (
@@ -246,8 +241,7 @@ fn test_extend_metadata() {
                     Some(&program_key),
                     Some(&program_data_key),
                     EXTEND_LENGTH as u16,
-                )
-                .unwrap(),
+                ),
                 &[
                     Check::success(),
                     Check::account(&metadata_key)
@@ -282,7 +276,7 @@ fn fail_extend_with_wrong_authority() {
     process_instructions(
         &[
             (
-                &allocate(&buffer_key, &buffer_key, None, None, None).unwrap(),
+                &allocate(&buffer_key, &buffer_key, None, None, None),
                 &[Check::success()],
             ),
             (
@@ -292,8 +286,7 @@ fn fail_extend_with_wrong_authority() {
                     None,
                     None,
                     EXTEND_LENGTH as u16,
-                )
-                .unwrap(),
+                ),
                 &[Check::err(ProgramError::IncorrectAuthority)],
             ),
         ],
@@ -315,11 +308,11 @@ fn fail_extend_without_rent_for_growth() {
     process_instructions(
         &[
             (
-                &allocate(&buffer_key, &buffer_key, None, None, None).unwrap(),
+                &allocate(&buffer_key, &buffer_key, None, None, None),
                 &[Check::success()],
             ),
             (
-                &extend(&buffer_key, &buffer_key, None, None, 1).unwrap(),
+                &extend(&buffer_key, &buffer_key, None, None, 1),
                 &[Check::err(ProgramError::AccountNotRentExempt)],
             ),
         ],
@@ -337,7 +330,7 @@ fn fail_extend_uninitialized_account() {
 
     process_instruction(
         (
-            &extend(&account_key, &account_key, None, None, EXTEND_LENGTH as u16).unwrap(),
+            &extend(&account_key, &account_key, None, None, EXTEND_LENGTH as u16),
             &[Check::err(ProgramError::InvalidAccountData)],
         ),
         &[
@@ -350,8 +343,7 @@ fn fail_extend_uninitialized_account() {
 #[test]
 fn fail_extend_with_invalid_instruction_data() {
     let buffer_key = Pubkey::new_unique();
-    let mut instruction =
-        extend(&buffer_key, &buffer_key, None, None, EXTEND_LENGTH as u16).unwrap();
+    let mut instruction = extend(&buffer_key, &buffer_key, None, None, EXTEND_LENGTH as u16);
     instruction.data.truncate(1);
 
     process_instruction(

--- a/program/tests/extend.rs
+++ b/program/tests/extend.rs
@@ -3,6 +3,7 @@ pub use setup::*;
 
 use mollusk_svm::{program::keyed_account_for_system_program, result::Check};
 use solana_account::Account;
+use solana_program_error::ProgramError;
 use solana_pubkey::Pubkey;
 use solana_sdk_ids::system_program;
 use spl_program_metadata::state::{buffer::Buffer, SEED_LEN};
@@ -193,6 +194,102 @@ fn test_extend_buffer() {
             (buffer_key, buffer_account),
             (PROGRAM_ID, Account::default()),
             keyed_account_for_system_program(),
+        ],
+    );
+}
+
+#[test]
+fn fail_extend_with_wrong_authority() {
+    let buffer_key = Pubkey::new_unique();
+    let wrong_authority_key = Pubkey::new_unique();
+    let buffer_account = create_funded_account(
+        minimum_balance_for(Buffer::LEN + EXTEND_LENGTH),
+        system_program::ID,
+    );
+
+    process_instructions(
+        &[
+            (
+                &allocate(&buffer_key, &buffer_key, None, None, None).unwrap(),
+                &[Check::success()],
+            ),
+            (
+                &extend(
+                    &buffer_key,
+                    &wrong_authority_key,
+                    None,
+                    None,
+                    EXTEND_LENGTH as u16,
+                )
+                .unwrap(),
+                &[Check::err(ProgramError::IncorrectAuthority)],
+            ),
+        ],
+        &[
+            (buffer_key, buffer_account),
+            (PROGRAM_ID, Account::default()),
+            (wrong_authority_key, Account::default()),
+            keyed_account_for_system_program(),
+        ],
+    );
+}
+
+#[test]
+fn fail_extend_without_rent_for_growth() {
+    let buffer_key = Pubkey::new_unique();
+    let buffer_account =
+        create_funded_account(minimum_balance_for(Buffer::LEN), system_program::ID);
+
+    process_instructions(
+        &[
+            (
+                &allocate(&buffer_key, &buffer_key, None, None, None).unwrap(),
+                &[Check::success()],
+            ),
+            (
+                &extend(&buffer_key, &buffer_key, None, None, 1).unwrap(),
+                &[Check::err(ProgramError::AccountNotRentExempt)],
+            ),
+        ],
+        &[
+            (buffer_key, buffer_account),
+            (PROGRAM_ID, Account::default()),
+            keyed_account_for_system_program(),
+        ],
+    );
+}
+
+#[test]
+fn fail_extend_uninitialized_account() {
+    let account_key = Pubkey::new_unique();
+
+    process_instruction(
+        (
+            &extend(&account_key, &account_key, None, None, EXTEND_LENGTH as u16).unwrap(),
+            &[Check::err(ProgramError::InvalidAccountData)],
+        ),
+        &[
+            (account_key, Account::default()),
+            (PROGRAM_ID, Account::default()),
+        ],
+    );
+}
+
+#[test]
+fn fail_extend_with_invalid_instruction_data() {
+    let buffer_key = Pubkey::new_unique();
+    let mut instruction =
+        extend(&buffer_key, &buffer_key, None, None, EXTEND_LENGTH as u16).unwrap();
+    instruction.data.truncate(1);
+
+    process_instruction(
+        (
+            &instruction,
+            &[Check::err(ProgramError::InvalidInstructionData)],
+        ),
+        &[
+            (buffer_key, Account::default()),
+            (PROGRAM_ID, Account::default()),
         ],
     );
 }

--- a/program/tests/initialize.rs
+++ b/program/tests/initialize.rs
@@ -212,6 +212,133 @@ fn test_initialize_from_buffer() {
 }
 
 #[test]
+fn fail_initialize_already_initialized_metadata() {
+    let authority_key = Pubkey::new_unique();
+
+    let program_data_key = Pubkey::new_unique();
+    let program_data_account = setup_program_data_account(Some(&authority_key));
+
+    let program_key = Pubkey::new_unique();
+    let program_account = setup_program_account(&program_data_key);
+
+    let mut seed = [0u8; SEED_LEN];
+    seed[0..3].copy_from_slice("idl".as_bytes());
+
+    let (metadata_key, _) =
+        Pubkey::find_program_address(&[program_key.as_ref(), &seed], &PROGRAM_ID);
+
+    let data = [1u8; 10];
+    let metadata_account = create_funded_account(
+        minimum_balance_for(Header::LEN + data.len()),
+        system_program::ID,
+    );
+
+    let instruction = initialize(
+        &authority_key,
+        &program_key,
+        Some(&program_data_key),
+        InitializeArgs {
+            canonical: true,
+            seed,
+            encoding: 0,
+            compression: 0,
+            format: 0,
+            data_source: 0,
+        },
+        Some(&data),
+    )
+    .unwrap();
+
+    process_instructions(
+        &[
+            (&instruction, &[Check::success()]),
+            // second attempt should fail since the metadata account is already initialized
+            (
+                &instruction,
+                &[Check::err(ProgramError::AccountAlreadyInitialized)],
+            ),
+        ],
+        &[
+            (metadata_key, metadata_account),
+            (PROGRAM_ID, Account::default()),
+            (authority_key, Account::default()),
+            (program_key, program_account),
+            (program_data_key, program_data_account),
+            keyed_account_for_system_program(),
+        ],
+    );
+}
+
+#[test]
+fn fail_initialize_from_buffer_with_instruction_data() {
+    let authority_key = Pubkey::new_unique();
+
+    let program_data_key = Pubkey::new_unique();
+    let program_data_account = setup_program_data_account(Some(&authority_key));
+
+    let program_key = Pubkey::new_unique();
+    let program_account = setup_program_account(&program_data_key);
+
+    let mut seed = [0u8; SEED_LEN];
+    seed[0..3].copy_from_slice("idl".as_bytes());
+
+    let (metadata_key, _) =
+        Pubkey::find_program_address(&[program_key.as_ref(), &seed], &PROGRAM_ID);
+
+    let buffer_data = [7u8; 12];
+    let buffer_account = create_funded_account(
+        minimum_balance_for(Buffer::LEN + buffer_data.len()),
+        system_program::ID,
+    );
+
+    process_instructions(
+        &[
+            (
+                &allocate(
+                    &metadata_key,
+                    &authority_key,
+                    Some(&program_key),
+                    Some(&program_data_key),
+                    Some(&seed),
+                )
+                .unwrap(),
+                &[Check::success()],
+            ),
+            (
+                &write(&metadata_key, &authority_key, None, 0, &buffer_data).unwrap(),
+                &[Check::success()],
+            ),
+            (
+                &initialize(
+                    &authority_key,
+                    &program_key,
+                    Some(&program_data_key),
+                    InitializeArgs {
+                        canonical: true,
+                        seed,
+                        encoding: 0,
+                        compression: 0,
+                        format: 0,
+                        data_source: 0,
+                    },
+                    Some(&[8u8; 4]), // instruction data
+                )
+                .unwrap(),
+                &[Check::err(ProgramError::InvalidInstructionData)],
+            ),
+        ],
+        &[
+            (metadata_key, buffer_account),
+            (PROGRAM_ID, Account::default()),
+            (authority_key, Account::default()),
+            (program_key, program_account),
+            (program_data_key, program_data_account),
+            keyed_account_for_system_program(),
+        ],
+    );
+}
+
+#[test]
 fn fail_initialize_with_wrong_metadata_pda() {
     let authority_key = Pubkey::new_unique();
 
@@ -259,6 +386,53 @@ fn fail_initialize_with_wrong_metadata_pda() {
 }
 
 #[test]
+fn fail_initialize_without_rent_exemption() {
+    let authority_key = Pubkey::new_unique();
+
+    let program_data_key = Pubkey::new_unique();
+    let program_data_account = setup_program_data_account(Some(&authority_key));
+
+    let program_key = Pubkey::new_unique();
+    let program_account = setup_program_account(&program_data_key);
+
+    let mut seed = [0u8; SEED_LEN];
+    seed[0..3].copy_from_slice("idl".as_bytes());
+
+    let (metadata_key, _) =
+        Pubkey::find_program_address(&[program_key.as_ref(), &seed], &PROGRAM_ID);
+    let metadata_account = create_funded_account(0, system_program::ID);
+
+    process_instruction(
+        (
+            &initialize(
+                &authority_key,
+                &program_key,
+                Some(&program_data_key),
+                InitializeArgs {
+                    canonical: true,
+                    seed,
+                    encoding: 0,
+                    compression: 0,
+                    format: 0,
+                    data_source: 0,
+                },
+                Some(&[1u8; 10]),
+            )
+            .unwrap(),
+            &[Check::err(ProgramError::AccountNotRentExempt)],
+        ),
+        &[
+            (metadata_key, metadata_account),
+            (PROGRAM_ID, Account::default()),
+            (authority_key, Account::default()),
+            (program_key, program_account),
+            (program_data_key, program_data_account),
+            keyed_account_for_system_program(),
+        ],
+    );
+}
+
+#[test]
 fn fail_initialize_without_data() {
     let authority_key = Pubkey::new_unique();
 
@@ -294,6 +468,54 @@ fn fail_initialize_without_data() {
             )
             .unwrap(),
             &[Check::err(ProgramError::InvalidInstructionData)],
+        ),
+        &[
+            (metadata_key, metadata_account),
+            (PROGRAM_ID, Account::default()),
+            (authority_key, Account::default()),
+            (program_key, program_account),
+            (program_data_key, program_data_account),
+            keyed_account_for_system_program(),
+        ],
+    );
+}
+
+#[test]
+fn fail_initialize_with_invalid_encoding() {
+    let authority_key = Pubkey::new_unique();
+
+    let program_data_key = Pubkey::new_unique();
+    let program_data_account = setup_program_data_account(Some(&authority_key));
+
+    let program_key = Pubkey::new_unique();
+    let program_account = setup_program_account(&program_data_key);
+
+    let mut seed = [0u8; SEED_LEN];
+    seed[0..3].copy_from_slice("idl".as_bytes());
+
+    let (metadata_key, _) =
+        Pubkey::find_program_address(&[program_key.as_ref(), &seed], &PROGRAM_ID);
+    let metadata_account =
+        create_funded_account(minimum_balance_for(Header::LEN + 10), system_program::ID);
+
+    process_instruction(
+        (
+            &initialize(
+                &authority_key,
+                &program_key,
+                Some(&program_data_key),
+                InitializeArgs {
+                    canonical: true,
+                    seed,
+                    encoding: 99,
+                    compression: 0,
+                    format: 0,
+                    data_source: 0,
+                },
+                Some(&[1u8; 10]),
+            )
+            .unwrap(),
+            &[Check::err(ProgramError::InvalidAccountData)],
         ),
         &[
             (metadata_key, metadata_account),

--- a/program/tests/initialize.rs
+++ b/program/tests/initialize.rs
@@ -42,8 +42,7 @@ fn test_initialize_canonical() {
             data_source: 0,
         },
         Some(&[1u8; 10]),
-    )
-    .unwrap();
+    );
 
     process_instruction(
         (
@@ -102,8 +101,7 @@ fn test_initialize_non_canonical() {
             data_source: 0,
         },
         Some(&[1u8; 10]),
-    )
-    .unwrap();
+    );
 
     process_instruction(
         (
@@ -159,15 +157,14 @@ fn test_initialize_from_buffer() {
                     Some(&program_key),
                     Some(&program_data_key),
                     Some(&seed),
-                )
-                .unwrap(),
+                ),
                 &[
                     Check::success(),
                     Check::account(&metadata_key).data_slice(0, &[1]).build(),
                 ],
             ),
             (
-                &write(&metadata_key, &authority_key, None, 0, &data).unwrap(),
+                &write(&metadata_key, &authority_key, None, 0, &data),
                 &[
                     Check::success(),
                     Check::account(&metadata_key)
@@ -189,8 +186,7 @@ fn test_initialize_from_buffer() {
                         data_source: 0,
                     },
                     None,
-                )
-                .unwrap(),
+                ),
                 &[
                     Check::success(),
                     Check::account(&metadata_key).data_slice(0, &[2]).build(),
@@ -246,8 +242,7 @@ fn fail_initialize_already_initialized_metadata() {
             data_source: 0,
         },
         Some(&data),
-    )
-    .unwrap();
+    );
 
     process_instructions(
         &[
@@ -300,12 +295,11 @@ fn fail_initialize_from_buffer_with_instruction_data() {
                     Some(&program_key),
                     Some(&program_data_key),
                     Some(&seed),
-                )
-                .unwrap(),
+                ),
                 &[Check::success()],
             ),
             (
-                &write(&metadata_key, &authority_key, None, 0, &buffer_data).unwrap(),
+                &write(&metadata_key, &authority_key, None, 0, &buffer_data),
                 &[Check::success()],
             ),
             (
@@ -322,8 +316,7 @@ fn fail_initialize_from_buffer_with_instruction_data() {
                         data_source: 0,
                     },
                     Some(&[8u8; 4]), // instruction data
-                )
-                .unwrap(),
+                ),
                 &[Check::err(ProgramError::InvalidInstructionData)],
             ),
         ],
@@ -368,8 +361,7 @@ fn fail_initialize_with_wrong_metadata_pda() {
             data_source: 0,
         },
         Some(&[1u8; 10]),
-    )
-    .unwrap();
+    );
     instruction.accounts[0].pubkey = wrong_metadata_key;
 
     process_instruction(
@@ -417,8 +409,7 @@ fn fail_initialize_without_rent_exemption() {
                     data_source: 0,
                 },
                 Some(&[1u8; 10]),
-            )
-            .unwrap(),
+            ),
             &[Check::err(ProgramError::AccountNotRentExempt)],
         ),
         &[
@@ -465,8 +456,7 @@ fn fail_initialize_without_data() {
                     data_source: 0,
                 },
                 None,
-            )
-            .unwrap(),
+            ),
             &[Check::err(ProgramError::InvalidInstructionData)],
         ),
         &[
@@ -513,8 +503,7 @@ fn fail_initialize_with_invalid_encoding() {
                     data_source: 0,
                 },
                 Some(&[1u8; 10]),
-            )
-            .unwrap(),
+            ),
             &[Check::err(ProgramError::InvalidAccountData)],
         ),
         &[
@@ -561,8 +550,7 @@ fn fail_initialize_external_data_with_wrong_length() {
                     data_source: 2,
                 },
                 Some(&[1u8; 10]),
-            )
-            .unwrap(),
+            ),
             &[Check::err(ProgramError::Custom(
                 ProgramMetadataError::InvalidDataLength as u32,
             ))],

--- a/program/tests/initialize.rs
+++ b/program/tests/initialize.rs
@@ -3,9 +3,13 @@ pub use setup::*;
 
 use mollusk_svm::{program::keyed_account_for_system_program, result::Check};
 use solana_account::Account;
+use solana_program_error::ProgramError;
 use solana_pubkey::Pubkey;
 use solana_sdk_ids::system_program;
-use spl_program_metadata::state::header::Header;
+use spl_program_metadata::{
+    error::ProgramMetadataError,
+    state::{buffer::Buffer, header::Header, SEED_LEN},
+};
 
 #[test]
 fn test_initialize_canonical() {
@@ -113,6 +117,233 @@ fn test_initialize_non_canonical() {
                     .data_slice(Header::LEN, &[1u8; 10])
                     .build(),
             ],
+        ),
+        &[
+            (metadata_key, metadata_account),
+            (PROGRAM_ID, Account::default()),
+            (authority_key, Account::default()),
+            (program_key, program_account),
+            (program_data_key, program_data_account),
+            keyed_account_for_system_program(),
+        ],
+    );
+}
+
+#[test]
+fn test_initialize_from_buffer() {
+    let authority_key = Pubkey::new_unique();
+
+    let program_data_key = Pubkey::new_unique();
+    let program_data_account = setup_program_data_account(Some(&authority_key));
+
+    let program_key = Pubkey::new_unique();
+    let program_account = setup_program_account(&program_data_key);
+
+    let mut seed = [0u8; SEED_LEN];
+    seed[0..3].copy_from_slice("idl".as_bytes());
+
+    let (metadata_key, _) =
+        Pubkey::find_program_address(&[program_key.as_ref(), &seed], &PROGRAM_ID);
+    let data = [7u8; 12];
+    let metadata_account = create_funded_account(
+        minimum_balance_for(Buffer::LEN + data.len()),
+        system_program::ID,
+    );
+
+    process_instructions(
+        &[
+            (
+                &allocate(
+                    &metadata_key,
+                    &authority_key,
+                    Some(&program_key),
+                    Some(&program_data_key),
+                    Some(&seed),
+                )
+                .unwrap(),
+                &[
+                    Check::success(),
+                    Check::account(&metadata_key).data_slice(0, &[1]).build(),
+                ],
+            ),
+            (
+                &write(&metadata_key, &authority_key, None, 0, &data).unwrap(),
+                &[
+                    Check::success(),
+                    Check::account(&metadata_key)
+                        .data_slice(Buffer::LEN, &data)
+                        .build(),
+                ],
+            ),
+            (
+                &initialize(
+                    &authority_key,
+                    &program_key,
+                    Some(&program_data_key),
+                    InitializeArgs {
+                        canonical: true,
+                        seed,
+                        encoding: 0,
+                        compression: 0,
+                        format: 0,
+                        data_source: 0,
+                    },
+                    None,
+                )
+                .unwrap(),
+                &[
+                    Check::success(),
+                    Check::account(&metadata_key).data_slice(0, &[2]).build(),
+                    Check::account(&metadata_key)
+                        .data_slice(Header::LEN, &data)
+                        .build(),
+                ],
+            ),
+        ],
+        &[
+            (metadata_key, metadata_account),
+            (PROGRAM_ID, Account::default()),
+            (authority_key, Account::default()),
+            (program_key, program_account),
+            (program_data_key, program_data_account),
+            keyed_account_for_system_program(),
+        ],
+    );
+}
+
+#[test]
+fn fail_initialize_with_wrong_metadata_pda() {
+    let authority_key = Pubkey::new_unique();
+
+    let program_data_key = Pubkey::new_unique();
+    let program_data_account = setup_program_data_account(Some(&authority_key));
+
+    let program_key = Pubkey::new_unique();
+    let program_account = setup_program_account(&program_data_key);
+
+    let mut seed = [0u8; SEED_LEN];
+    seed[0..3].copy_from_slice("idl".as_bytes());
+
+    let wrong_metadata_key = Pubkey::new_unique();
+    let metadata_account =
+        create_funded_account(minimum_balance_for(Header::LEN + 10), system_program::ID);
+
+    let mut instruction = initialize(
+        &authority_key,
+        &program_key,
+        Some(&program_data_key),
+        InitializeArgs {
+            canonical: true,
+            seed,
+            encoding: 0,
+            compression: 0,
+            format: 0,
+            data_source: 0,
+        },
+        Some(&[1u8; 10]),
+    )
+    .unwrap();
+    instruction.accounts[0].pubkey = wrong_metadata_key;
+
+    process_instruction(
+        (&instruction, &[Check::err(ProgramError::InvalidSeeds)]),
+        &[
+            (wrong_metadata_key, metadata_account),
+            (PROGRAM_ID, Account::default()),
+            (authority_key, Account::default()),
+            (program_key, program_account),
+            (program_data_key, program_data_account),
+            keyed_account_for_system_program(),
+        ],
+    );
+}
+
+#[test]
+fn fail_initialize_without_data() {
+    let authority_key = Pubkey::new_unique();
+
+    let program_data_key = Pubkey::new_unique();
+    let program_data_account = setup_program_data_account(Some(&authority_key));
+
+    let program_key = Pubkey::new_unique();
+    let program_account = setup_program_account(&program_data_key);
+
+    let mut seed = [0u8; SEED_LEN];
+    seed[0..3].copy_from_slice("idl".as_bytes());
+
+    let (metadata_key, _) =
+        Pubkey::find_program_address(&[program_key.as_ref(), &seed], &PROGRAM_ID);
+    let metadata_account =
+        create_funded_account(minimum_balance_for(Header::LEN), system_program::ID);
+
+    process_instruction(
+        (
+            &initialize(
+                &authority_key,
+                &program_key,
+                Some(&program_data_key),
+                InitializeArgs {
+                    canonical: true,
+                    seed,
+                    encoding: 0,
+                    compression: 0,
+                    format: 0,
+                    data_source: 0,
+                },
+                None,
+            )
+            .unwrap(),
+            &[Check::err(ProgramError::InvalidInstructionData)],
+        ),
+        &[
+            (metadata_key, metadata_account),
+            (PROGRAM_ID, Account::default()),
+            (authority_key, Account::default()),
+            (program_key, program_account),
+            (program_data_key, program_data_account),
+            keyed_account_for_system_program(),
+        ],
+    );
+}
+
+#[test]
+fn fail_initialize_external_data_with_wrong_length() {
+    let authority_key = Pubkey::new_unique();
+
+    let program_data_key = Pubkey::new_unique();
+    let program_data_account = setup_program_data_account(Some(&authority_key));
+
+    let program_key = Pubkey::new_unique();
+    let program_account = setup_program_account(&program_data_key);
+
+    let mut seed = [0u8; SEED_LEN];
+    seed[0..3].copy_from_slice("idl".as_bytes());
+
+    let (metadata_key, _) =
+        Pubkey::find_program_address(&[program_key.as_ref(), &seed], &PROGRAM_ID);
+    let metadata_account =
+        create_funded_account(minimum_balance_for(Header::LEN + 10), system_program::ID);
+
+    process_instruction(
+        (
+            &initialize(
+                &authority_key,
+                &program_key,
+                Some(&program_data_key),
+                InitializeArgs {
+                    canonical: true,
+                    seed,
+                    encoding: 0,
+                    compression: 0,
+                    format: 0,
+                    data_source: 2,
+                },
+                Some(&[1u8; 10]),
+            )
+            .unwrap(),
+            &[Check::err(ProgramError::Custom(
+                ProgramMetadataError::InvalidDataLength as u32,
+            ))],
         ),
         &[
             (metadata_key, metadata_account),

--- a/program/tests/set_authority.rs
+++ b/program/tests/set_authority.rs
@@ -1,0 +1,342 @@
+mod setup;
+pub use setup::*;
+
+use mollusk_svm::{program::keyed_account_for_system_program, result::Check};
+use solana_account::Account;
+use solana_program_error::ProgramError;
+use solana_pubkey::Pubkey;
+use solana_sdk_ids::system_program;
+use spl_program_metadata::state::{buffer::Buffer, header::Header, SEED_LEN};
+
+#[test]
+fn test_set_authority_metadata() {
+    let authority_key = Pubkey::new_unique();
+    let new_authority_key = Pubkey::new_unique();
+
+    let program_data_key = Pubkey::new_unique();
+    let program_data_account = setup_program_data_account(Some(&authority_key));
+
+    let program_key = Pubkey::new_unique();
+    let program_account = setup_program_account(&program_data_key);
+
+    let mut seed = [0u8; SEED_LEN];
+    seed[0..3].copy_from_slice("idl".as_bytes());
+
+    let (metadata_key, _) =
+        Pubkey::find_program_address(&[program_key.as_ref(), &seed], &PROGRAM_ID);
+
+    let initial_data = [1u8; 5];
+    let updated_data = [4u8; 8];
+    let metadata_account = create_funded_account(
+        minimum_balance_for(Header::LEN + updated_data.len()),
+        system_program::ID,
+    );
+
+    process_instructions(
+        &[
+            (
+                &initialize(
+                    &authority_key,
+                    &program_key,
+                    Some(&program_data_key),
+                    InitializeArgs {
+                        canonical: true,
+                        seed,
+                        encoding: 0,
+                        compression: 0,
+                        format: 0,
+                        data_source: 0,
+                    },
+                    Some(&initial_data),
+                )
+                .unwrap(),
+                &[Check::success()],
+            ),
+            (
+                &set_authority(
+                    &metadata_key,
+                    &authority_key,
+                    Some(&program_key),
+                    Some(&program_data_key),
+                    Some(&new_authority_key),
+                )
+                .unwrap(),
+                &[Check::success()],
+            ),
+            (
+                &set_data(
+                    &metadata_key,
+                    &new_authority_key,
+                    None,
+                    None,
+                    None,
+                    SetDataArgs {
+                        encoding: 0,
+                        compression: 0,
+                        format: 0,
+                        data_source: Some(0),
+                    },
+                    Some(&updated_data),
+                )
+                .unwrap(),
+                &[
+                    Check::success(),
+                    // metadata data
+                    Check::account(&metadata_key)
+                        .data_slice(Header::LEN, &updated_data)
+                        .build(),
+                ],
+            ),
+        ],
+        &[
+            (metadata_key, metadata_account),
+            (PROGRAM_ID, Account::default()),
+            (authority_key, Account::default()),
+            (new_authority_key, Account::default()),
+            (program_key, program_account),
+            (program_data_key, program_data_account),
+            keyed_account_for_system_program(),
+        ],
+    );
+}
+
+#[test]
+fn test_set_authority_buffer() {
+    let buffer_key = Pubkey::new_unique();
+    let new_authority_key = Pubkey::new_unique();
+    let data = [5u8; 8];
+
+    let buffer_account = create_funded_account(
+        minimum_balance_for(Buffer::LEN + data.len()),
+        system_program::ID,
+    );
+
+    process_instructions(
+        &[
+            (
+                &allocate(&buffer_key, &buffer_key, None, None, None).unwrap(),
+                &[
+                    Check::success(),
+                    // account discriminator
+                    Check::account(&buffer_key).data_slice(0, &[1]).build(),
+                ],
+            ),
+            (
+                &set_authority(
+                    &buffer_key,
+                    &buffer_key,
+                    None,
+                    None,
+                    Some(&new_authority_key),
+                )
+                .unwrap(),
+                &[Check::success()],
+            ),
+            (
+                &write(&buffer_key, &new_authority_key, None, 0, &data).unwrap(),
+                &[
+                    Check::success(),
+                    // buffer data
+                    Check::account(&buffer_key)
+                        .data_slice(Buffer::LEN, &data)
+                        .build(),
+                ],
+            ),
+        ],
+        &[
+            (buffer_key, buffer_account),
+            (PROGRAM_ID, Account::default()),
+            (new_authority_key, Account::default()),
+            keyed_account_for_system_program(),
+        ],
+    );
+}
+
+#[test]
+fn test_set_authority_non_canonical_metadata() {
+    let authority_key = Pubkey::new_unique();
+    let new_authority_key = Pubkey::new_unique();
+
+    let program_data_key = Pubkey::new_unique();
+    let program_data_account = setup_program_data_account(Some(&authority_key));
+
+    let program_key = Pubkey::new_unique();
+    let program_account = setup_program_account(&program_data_key);
+
+    let mut seed = [0u8; SEED_LEN];
+    seed[0..3].copy_from_slice("idl".as_bytes());
+
+    let (metadata_key, _) = Pubkey::find_program_address(
+        &[program_key.as_ref(), authority_key.as_ref(), &seed],
+        &PROGRAM_ID,
+    );
+    let metadata_account =
+        create_funded_account(minimum_balance_for(Header::LEN + 5), system_program::ID);
+
+    process_instructions(
+        &[
+            (
+                &initialize(
+                    &authority_key,
+                    &program_key,
+                    None,
+                    InitializeArgs {
+                        canonical: false,
+                        seed,
+                        encoding: 0,
+                        compression: 0,
+                        format: 0,
+                        data_source: 0,
+                    },
+                    Some(&[1u8; 5]),
+                )
+                .unwrap(),
+                &[Check::success()],
+            ),
+            (
+                &set_authority(
+                    &metadata_key,
+                    &authority_key,
+                    None,
+                    None,
+                    Some(&new_authority_key),
+                )
+                .unwrap(),
+                &[Check::err(ProgramError::InvalidAccountData)],
+            ),
+        ],
+        &[
+            (metadata_key, metadata_account),
+            (PROGRAM_ID, Account::default()),
+            (authority_key, Account::default()),
+            (program_key, program_account),
+            (program_data_key, program_data_account),
+            keyed_account_for_system_program(),
+        ],
+    );
+}
+
+#[test]
+fn fail_set_authority_with_wrong_authority() {
+    let authority_key = Pubkey::new_unique();
+    let wrong_authority_key = Pubkey::new_unique();
+    let new_authority_key = Pubkey::new_unique();
+
+    let program_data_key = Pubkey::new_unique();
+    let program_data_account = setup_program_data_account(Some(&authority_key));
+
+    let program_key = Pubkey::new_unique();
+    let program_account = setup_program_account(&program_data_key);
+
+    let mut seed = [0u8; SEED_LEN];
+    seed[0..3].copy_from_slice("idl".as_bytes());
+
+    let (metadata_key, _) =
+        Pubkey::find_program_address(&[program_key.as_ref(), &seed], &PROGRAM_ID);
+    let metadata_account =
+        create_funded_account(minimum_balance_for(Header::LEN + 5), system_program::ID);
+
+    process_instructions(
+        &[
+            (
+                &initialize(
+                    &authority_key,
+                    &program_key,
+                    Some(&program_data_key),
+                    InitializeArgs {
+                        canonical: true,
+                        seed,
+                        encoding: 0,
+                        compression: 0,
+                        format: 0,
+                        data_source: 0,
+                    },
+                    Some(&[1u8; 5]),
+                )
+                .unwrap(),
+                &[Check::success()],
+            ),
+            (
+                &set_authority(
+                    &metadata_key,
+                    &wrong_authority_key,
+                    Some(&program_key),
+                    Some(&program_data_key),
+                    Some(&new_authority_key),
+                )
+                .unwrap(),
+                &[Check::err(ProgramError::IncorrectAuthority)],
+            ),
+        ],
+        &[
+            (metadata_key, metadata_account),
+            (PROGRAM_ID, Account::default()),
+            (authority_key, Account::default()),
+            (wrong_authority_key, Account::default()),
+            (program_key, program_account),
+            (program_data_key, program_data_account),
+            keyed_account_for_system_program(),
+        ],
+    );
+}
+
+#[test]
+fn fail_set_authority_remove_buffer_authority() {
+    let buffer_key = Pubkey::new_unique();
+    let buffer_account =
+        create_funded_account(minimum_balance_for(Buffer::LEN), system_program::ID);
+
+    process_instructions(
+        &[
+            (
+                &allocate(&buffer_key, &buffer_key, None, None, None).unwrap(),
+                &[Check::success()],
+            ),
+            (
+                &set_authority(&buffer_key, &buffer_key, None, None, None).unwrap(),
+                &[Check::err(ProgramError::InvalidArgument)],
+            ),
+        ],
+        &[
+            (buffer_key, buffer_account),
+            (PROGRAM_ID, Account::default()),
+            keyed_account_for_system_program(),
+        ],
+    );
+}
+
+#[test]
+fn fail_set_authority_with_missing_new_authority_bytes() {
+    let buffer_key = Pubkey::new_unique();
+    let new_authority_key = Pubkey::new_unique();
+    let buffer_account =
+        create_funded_account(minimum_balance_for(Buffer::LEN), system_program::ID);
+
+    let mut instruction = set_authority(
+        &buffer_key,
+        &buffer_key,
+        None,
+        None,
+        Some(&new_authority_key),
+    )
+    .unwrap();
+    instruction.data.truncate(2);
+
+    process_instructions(
+        &[
+            (
+                &allocate(&buffer_key, &buffer_key, None, None, None).unwrap(),
+                &[Check::success()],
+            ),
+            (
+                &instruction,
+                &[Check::err(ProgramError::InvalidInstructionData)],
+            ),
+        ],
+        &[
+            (buffer_key, buffer_account),
+            (PROGRAM_ID, Account::default()),
+            keyed_account_for_system_program(),
+        ],
+    );
+}

--- a/program/tests/set_authority.rs
+++ b/program/tests/set_authority.rs
@@ -6,7 +6,10 @@ use solana_account::Account;
 use solana_program_error::ProgramError;
 use solana_pubkey::Pubkey;
 use solana_sdk_ids::system_program;
-use spl_program_metadata::state::{buffer::Buffer, header::Header, SEED_LEN};
+use spl_program_metadata::{
+    error::ProgramMetadataError,
+    state::{buffer::Buffer, header::Header, SEED_LEN},
+};
 
 #[test]
 fn test_set_authority_metadata() {
@@ -101,6 +104,104 @@ fn test_set_authority_metadata() {
 }
 
 #[test]
+fn test_remove_metadata_authority() {
+    let authority_key = Pubkey::new_unique();
+    let new_authority_key = Pubkey::new_unique();
+
+    let program_data_key = Pubkey::new_unique();
+    let program_data_account = setup_program_data_account(Some(&authority_key));
+
+    let program_key = Pubkey::new_unique();
+    let program_account = setup_program_account(&program_data_key);
+
+    let mut seed = [0u8; SEED_LEN];
+    seed[0..3].copy_from_slice("idl".as_bytes());
+
+    let (metadata_key, _) =
+        Pubkey::find_program_address(&[program_key.as_ref(), &seed], &PROGRAM_ID);
+
+    let initial_data = [1u8; 5];
+    let updated_data = [8u8; 7];
+    let metadata_account = create_funded_account(
+        minimum_balance_for(Header::LEN + updated_data.len()),
+        system_program::ID,
+    );
+
+    process_instructions(
+        &[
+            (
+                &initialize(
+                    &authority_key,
+                    &program_key,
+                    Some(&program_data_key),
+                    InitializeArgs {
+                        canonical: true,
+                        seed,
+                        encoding: 0,
+                        compression: 0,
+                        format: 0,
+                        data_source: 0,
+                    },
+                    Some(&initial_data),
+                )
+                .unwrap(),
+                &[Check::success()],
+            ),
+            (
+                &set_authority(
+                    &metadata_key,
+                    &authority_key,
+                    Some(&program_key),
+                    Some(&program_data_key),
+                    Some(&new_authority_key),
+                )
+                .unwrap(),
+                &[Check::success()],
+            ),
+            (
+                &set_authority(&metadata_key, &new_authority_key, None, None, None).unwrap(),
+                &[Check::success()],
+            ),
+            // Set data with the program upgrade authority after removing the
+            // metadata authority to ensure the program upgrade authority can
+            // still update the metadata.
+            (
+                &set_data(
+                    &metadata_key,
+                    &authority_key,
+                    None,
+                    Some(&program_key),
+                    Some(&program_data_key),
+                    SetDataArgs {
+                        encoding: 0,
+                        compression: 0,
+                        format: 0,
+                        data_source: Some(0),
+                    },
+                    Some(&updated_data),
+                )
+                .unwrap(),
+                &[
+                    Check::success(),
+                    Check::account(&metadata_key)
+                        .data_slice(Header::LEN, &updated_data)
+                        .build(),
+                ],
+            ),
+        ],
+        &[
+            (metadata_key, metadata_account),
+            (PROGRAM_ID, Account::default()),
+            (authority_key, Account::default()),
+            (new_authority_key, Account::default()),
+            (program_key, program_account),
+            (program_data_key, program_data_account),
+            keyed_account_for_system_program(),
+        ],
+    );
+}
+
+#[test]
 fn test_set_authority_buffer() {
     let buffer_key = Pubkey::new_unique();
     let new_authority_key = Pubkey::new_unique();
@@ -147,6 +248,80 @@ fn test_set_authority_buffer() {
             (buffer_key, buffer_account),
             (PROGRAM_ID, Account::default()),
             (new_authority_key, Account::default()),
+            keyed_account_for_system_program(),
+        ],
+    );
+}
+
+#[test]
+fn fail_set_authority_immutable_metadata() {
+    let authority_key = Pubkey::new_unique();
+    let new_authority_key = Pubkey::new_unique();
+
+    let program_data_key = Pubkey::new_unique();
+    let program_data_account = setup_program_data_account(Some(&authority_key));
+
+    let program_key = Pubkey::new_unique();
+    let program_account = setup_program_account(&program_data_key);
+
+    let mut seed = [0u8; SEED_LEN];
+    seed[0..3].copy_from_slice("idl".as_bytes());
+
+    let (metadata_key, _) =
+        Pubkey::find_program_address(&[program_key.as_ref(), &seed], &PROGRAM_ID);
+    let metadata_account =
+        create_funded_account(minimum_balance_for(Header::LEN + 5), system_program::ID);
+
+    process_instructions(
+        &[
+            (
+                &initialize(
+                    &authority_key,
+                    &program_key,
+                    Some(&program_data_key),
+                    InitializeArgs {
+                        canonical: true,
+                        seed,
+                        encoding: 0,
+                        compression: 0,
+                        format: 0,
+                        data_source: 0,
+                    },
+                    Some(&[1u8; 5]),
+                )
+                .unwrap(),
+                &[Check::success()],
+            ),
+            (
+                &set_immutable(
+                    &metadata_key,
+                    &authority_key,
+                    Some(&program_key),
+                    Some(&program_data_key),
+                )
+                .unwrap(),
+                &[Check::success()],
+            ),
+            (
+                &set_authority(
+                    &metadata_key,
+                    &authority_key,
+                    Some(&program_key),
+                    Some(&program_data_key),
+                    Some(&new_authority_key),
+                )
+                .unwrap(),
+                &[Check::err(ProgramError::Custom(
+                    ProgramMetadataError::ImmutableMetadataAccount as u32,
+                ))],
+            ),
+        ],
+        &[
+            (metadata_key, metadata_account),
+            (PROGRAM_ID, Account::default()),
+            (authority_key, Account::default()),
+            (program_key, program_account),
+            (program_data_key, program_data_account),
             keyed_account_for_system_program(),
         ],
     );

--- a/program/tests/set_authority.rs
+++ b/program/tests/set_authority.rs
@@ -51,8 +51,7 @@ fn test_set_authority_metadata() {
                         data_source: 0,
                     },
                     Some(&initial_data),
-                )
-                .unwrap(),
+                ),
                 &[Check::success()],
             ),
             (
@@ -62,8 +61,7 @@ fn test_set_authority_metadata() {
                     Some(&program_key),
                     Some(&program_data_key),
                     Some(&new_authority_key),
-                )
-                .unwrap(),
+                ),
                 &[Check::success()],
             ),
             (
@@ -80,8 +78,7 @@ fn test_set_authority_metadata() {
                         data_source: Some(0),
                     },
                     Some(&updated_data),
-                )
-                .unwrap(),
+                ),
                 &[
                     Check::success(),
                     // metadata data
@@ -143,8 +140,7 @@ fn test_remove_metadata_authority() {
                         data_source: 0,
                     },
                     Some(&initial_data),
-                )
-                .unwrap(),
+                ),
                 &[Check::success()],
             ),
             (
@@ -154,12 +150,11 @@ fn test_remove_metadata_authority() {
                     Some(&program_key),
                     Some(&program_data_key),
                     Some(&new_authority_key),
-                )
-                .unwrap(),
+                ),
                 &[Check::success()],
             ),
             (
-                &set_authority(&metadata_key, &new_authority_key, None, None, None).unwrap(),
+                &set_authority(&metadata_key, &new_authority_key, None, None, None),
                 &[Check::success()],
             ),
             // Set data with the program upgrade authority after removing the
@@ -179,8 +174,7 @@ fn test_remove_metadata_authority() {
                         data_source: Some(0),
                     },
                     Some(&updated_data),
-                )
-                .unwrap(),
+                ),
                 &[
                     Check::success(),
                     Check::account(&metadata_key)
@@ -215,7 +209,7 @@ fn test_set_authority_buffer() {
     process_instructions(
         &[
             (
-                &allocate(&buffer_key, &buffer_key, None, None, None).unwrap(),
+                &allocate(&buffer_key, &buffer_key, None, None, None),
                 &[
                     Check::success(),
                     // account discriminator
@@ -229,12 +223,11 @@ fn test_set_authority_buffer() {
                     None,
                     None,
                     Some(&new_authority_key),
-                )
-                .unwrap(),
+                ),
                 &[Check::success()],
             ),
             (
-                &write(&buffer_key, &new_authority_key, None, 0, &data).unwrap(),
+                &write(&buffer_key, &new_authority_key, None, 0, &data),
                 &[
                     Check::success(),
                     // buffer data
@@ -288,8 +281,7 @@ fn fail_set_authority_immutable_metadata() {
                         data_source: 0,
                     },
                     Some(&[1u8; 5]),
-                )
-                .unwrap(),
+                ),
                 &[Check::success()],
             ),
             (
@@ -298,8 +290,7 @@ fn fail_set_authority_immutable_metadata() {
                     &authority_key,
                     Some(&program_key),
                     Some(&program_data_key),
-                )
-                .unwrap(),
+                ),
                 &[Check::success()],
             ),
             (
@@ -309,8 +300,7 @@ fn fail_set_authority_immutable_metadata() {
                     Some(&program_key),
                     Some(&program_data_key),
                     Some(&new_authority_key),
-                )
-                .unwrap(),
+                ),
                 &[Check::err(ProgramError::Custom(
                     ProgramMetadataError::ImmutableMetadataAccount as u32,
                 ))],
@@ -364,8 +354,7 @@ fn test_set_authority_non_canonical_metadata() {
                         data_source: 0,
                     },
                     Some(&[1u8; 5]),
-                )
-                .unwrap(),
+                ),
                 &[Check::success()],
             ),
             (
@@ -375,8 +364,7 @@ fn test_set_authority_non_canonical_metadata() {
                     None,
                     None,
                     Some(&new_authority_key),
-                )
-                .unwrap(),
+                ),
                 &[Check::err(ProgramError::InvalidAccountData)],
             ),
         ],
@@ -427,8 +415,7 @@ fn fail_set_authority_with_wrong_authority() {
                         data_source: 0,
                     },
                     Some(&[1u8; 5]),
-                )
-                .unwrap(),
+                ),
                 &[Check::success()],
             ),
             (
@@ -438,8 +425,7 @@ fn fail_set_authority_with_wrong_authority() {
                     Some(&program_key),
                     Some(&program_data_key),
                     Some(&new_authority_key),
-                )
-                .unwrap(),
+                ),
                 &[Check::err(ProgramError::IncorrectAuthority)],
             ),
         ],
@@ -464,11 +450,11 @@ fn fail_set_authority_remove_buffer_authority() {
     process_instructions(
         &[
             (
-                &allocate(&buffer_key, &buffer_key, None, None, None).unwrap(),
+                &allocate(&buffer_key, &buffer_key, None, None, None),
                 &[Check::success()],
             ),
             (
-                &set_authority(&buffer_key, &buffer_key, None, None, None).unwrap(),
+                &set_authority(&buffer_key, &buffer_key, None, None, None),
                 &[Check::err(ProgramError::InvalidArgument)],
             ),
         ],
@@ -493,14 +479,13 @@ fn fail_set_authority_with_missing_new_authority_bytes() {
         None,
         None,
         Some(&new_authority_key),
-    )
-    .unwrap();
+    );
     instruction.data.truncate(2);
 
     process_instructions(
         &[
             (
-                &allocate(&buffer_key, &buffer_key, None, None, None).unwrap(),
+                &allocate(&buffer_key, &buffer_key, None, None, None),
                 &[Check::success()],
             ),
             (

--- a/program/tests/set_data.rs
+++ b/program/tests/set_data.rs
@@ -215,6 +215,168 @@ fn test_set_data_buffer() {
 }
 
 #[test]
+fn test_set_data_without_replacing_data() {
+    let authority_key = Pubkey::new_unique();
+
+    let program_data_key = Pubkey::new_unique();
+    let program_data_account = setup_program_data_account(Some(&authority_key));
+
+    let program_key = Pubkey::new_unique();
+    let program_account = setup_program_account(&program_data_key);
+
+    let mut seed = [0u8; SEED_LEN];
+    seed[0..3].copy_from_slice("idl".as_bytes());
+
+    let (metadata_key, _) =
+        Pubkey::find_program_address(&[program_key.as_ref(), &seed], &PROGRAM_ID);
+
+    let data = [4u8; 6];
+    let metadata_account = create_funded_account(
+        minimum_balance_for(Header::LEN + data.len()),
+        system_program::ID,
+    );
+
+    process_instructions(
+        &[
+            (
+                &initialize(
+                    &authority_key,
+                    &program_key,
+                    Some(&program_data_key),
+                    InitializeArgs {
+                        canonical: true,
+                        seed,
+                        encoding: 0,
+                        compression: 0,
+                        format: 0,
+                        data_source: 0,
+                    },
+                    Some(&data),
+                )
+                .unwrap(),
+                &[Check::success()],
+            ),
+            (
+                &set_data(
+                    &metadata_key,
+                    &authority_key,
+                    None,
+                    Some(&program_key),
+                    Some(&program_data_key),
+                    SetDataArgs {
+                        encoding: 1,
+                        compression: 2,
+                        format: 3,
+                        data_source: None,
+                    },
+                    None,
+                )
+                .unwrap(),
+                &[
+                    Check::success(),
+                    Check::account(&metadata_key)
+                        .space(Header::LEN + data.len())
+                        .build(),
+                    Check::account(&metadata_key)
+                        .data_slice(Header::LEN, &data)
+                        .build(),
+                ],
+            ),
+        ],
+        &[
+            (metadata_key, metadata_account),
+            (PROGRAM_ID, Account::default()),
+            (authority_key, Account::default()),
+            (program_key, program_account),
+            (program_data_key, program_data_account),
+            keyed_account_for_system_program(),
+        ],
+    );
+}
+
+#[test]
+fn test_set_data_shrinks_metadata_account() {
+    let authority_key = Pubkey::new_unique();
+
+    let program_data_key = Pubkey::new_unique();
+    let program_data_account = setup_program_data_account(Some(&authority_key));
+
+    let program_key = Pubkey::new_unique();
+    let program_account = setup_program_account(&program_data_key);
+
+    let mut seed = [0u8; SEED_LEN];
+    seed[0..3].copy_from_slice("idl".as_bytes());
+
+    let (metadata_key, _) =
+        Pubkey::find_program_address(&[program_key.as_ref(), &seed], &PROGRAM_ID);
+
+    let initial_data = [1u8; 12];
+    let updated_data = [2u8; 4];
+
+    let metadata_account = create_funded_account(
+        minimum_balance_for(Header::LEN + initial_data.len()),
+        system_program::ID,
+    );
+
+    process_instructions(
+        &[
+            (
+                &initialize(
+                    &authority_key,
+                    &program_key,
+                    Some(&program_data_key),
+                    InitializeArgs {
+                        canonical: true,
+                        seed,
+                        encoding: 0,
+                        compression: 0,
+                        format: 0,
+                        data_source: 0,
+                    },
+                    Some(&initial_data),
+                )
+                .unwrap(),
+                &[Check::success()],
+            ),
+            (
+                &set_data(
+                    &metadata_key,
+                    &authority_key,
+                    None,
+                    Some(&program_key),
+                    Some(&program_data_key),
+                    SetDataArgs {
+                        encoding: 0,
+                        compression: 0,
+                        format: 0,
+                        data_source: Some(0),
+                    },
+                    Some(&updated_data),
+                )
+                .unwrap(),
+                &[
+                    Check::success(),
+                    Check::account(&metadata_key)
+                        .space(Header::LEN + updated_data.len())
+                        .build(),
+                    Check::account(&metadata_key)
+                        .data_slice(Header::LEN, &updated_data)
+                        .build(),
+                ],
+            ),
+        ],
+        &[
+            (metadata_key, metadata_account),
+            (PROGRAM_ID, Account::default()),
+            (authority_key, Account::default()),
+            (program_key, program_account),
+            (program_data_key, program_data_account),
+            keyed_account_for_system_program(),
+        ],
+    );
+}
+
+#[test]
 fn fail_set_data_with_wrong_authority() {
     let authority_key = Pubkey::new_unique();
     let wrong_authority_key = Pubkey::new_unique();
@@ -370,6 +532,150 @@ fn fail_set_data_from_empty_buffer_as_direct_data() {
 }
 
 #[test]
+fn fail_set_data_with_invalid_compression() {
+    let authority_key = Pubkey::new_unique();
+
+    let program_data_key = Pubkey::new_unique();
+    let program_data_account = setup_program_data_account(Some(&authority_key));
+
+    let program_key = Pubkey::new_unique();
+    let program_account = setup_program_account(&program_data_key);
+
+    let mut seed = [0u8; SEED_LEN];
+    seed[0..3].copy_from_slice("idl".as_bytes());
+
+    let (metadata_key, _) =
+        Pubkey::find_program_address(&[program_key.as_ref(), &seed], &PROGRAM_ID);
+
+    let data = [1u8; 5];
+    let metadata_account = create_funded_account(
+        minimum_balance_for(Header::LEN + data.len()),
+        system_program::ID,
+    );
+
+    process_instructions(
+        &[
+            (
+                &initialize(
+                    &authority_key,
+                    &program_key,
+                    Some(&program_data_key),
+                    InitializeArgs {
+                        canonical: true,
+                        seed,
+                        encoding: 0,
+                        compression: 0,
+                        format: 0,
+                        data_source: 0,
+                    },
+                    Some(&data),
+                )
+                .unwrap(),
+                &[Check::success()],
+            ),
+            (
+                &set_data(
+                    &metadata_key,
+                    &authority_key,
+                    None,
+                    Some(&program_key),
+                    Some(&program_data_key),
+                    SetDataArgs {
+                        encoding: 0,
+                        compression: 99, // <- invalid compression
+                        format: 0,
+                        data_source: None,
+                    },
+                    None,
+                )
+                .unwrap(),
+                &[Check::err(ProgramError::InvalidInstructionData)],
+            ),
+        ],
+        &[
+            (metadata_key, metadata_account),
+            (PROGRAM_ID, Account::default()),
+            (authority_key, Account::default()),
+            (program_key, program_account),
+            (program_data_key, program_data_account),
+            keyed_account_for_system_program(),
+        ],
+    );
+}
+
+#[test]
+fn fail_set_data_with_invalid_data_source() {
+    let authority_key = Pubkey::new_unique();
+
+    let program_data_key = Pubkey::new_unique();
+    let program_data_account = setup_program_data_account(Some(&authority_key));
+
+    let program_key = Pubkey::new_unique();
+    let program_account = setup_program_account(&program_data_key);
+
+    let mut seed = [0u8; SEED_LEN];
+    seed[0..3].copy_from_slice("idl".as_bytes());
+
+    let (metadata_key, _) =
+        Pubkey::find_program_address(&[program_key.as_ref(), &seed], &PROGRAM_ID);
+
+    let data = [1u8; 5];
+    let metadata_account = create_funded_account(
+        minimum_balance_for(Header::LEN + data.len()),
+        system_program::ID,
+    );
+
+    process_instructions(
+        &[
+            (
+                &initialize(
+                    &authority_key,
+                    &program_key,
+                    Some(&program_data_key),
+                    InitializeArgs {
+                        canonical: true,
+                        seed,
+                        encoding: 0,
+                        compression: 0,
+                        format: 0,
+                        data_source: 0,
+                    },
+                    Some(&data),
+                )
+                .unwrap(),
+                &[Check::success()],
+            ),
+            (
+                &set_data(
+                    &metadata_key,
+                    &authority_key,
+                    None,
+                    Some(&program_key),
+                    Some(&program_data_key),
+                    SetDataArgs {
+                        encoding: 0,
+                        compression: 0,
+                        format: 0,
+                        data_source: Some(99), // <- invalid data source
+                    },
+                    Some(&[2u8; 5]),
+                )
+                .unwrap(),
+                &[Check::err(ProgramError::InvalidInstructionData)],
+            ),
+        ],
+        &[
+            (metadata_key, metadata_account),
+            (PROGRAM_ID, Account::default()),
+            (authority_key, Account::default()),
+            (program_key, program_account),
+            (program_data_key, program_data_account),
+            keyed_account_for_system_program(),
+        ],
+    );
+}
+
+#[test]
 fn fail_set_data_from_wrong_owner_buffer() {
     let authority_key = Pubkey::new_unique();
 
@@ -502,7 +808,7 @@ fn fail_set_data_with_invalid_encoding() {
                     None,
                 )
                 .unwrap(),
-                &[Check::err(ProgramError::InvalidAccountData)],
+                &[Check::err(ProgramError::InvalidInstructionData)],
             ),
         ],
         &[

--- a/program/tests/set_data.rs
+++ b/program/tests/set_data.rs
@@ -1,0 +1,517 @@
+mod setup;
+pub use setup::*;
+
+use mollusk_svm::{program::keyed_account_for_system_program, result::Check};
+use solana_account::Account;
+use solana_program_error::ProgramError;
+use solana_pubkey::Pubkey;
+use solana_sdk_ids::system_program;
+use spl_program_metadata::{
+    error::ProgramMetadataError,
+    state::{buffer::Buffer, header::Header, SEED_LEN},
+};
+
+#[test]
+fn test_set_data_instruction_data() {
+    let authority_key = Pubkey::new_unique();
+
+    let program_data_key = Pubkey::new_unique();
+    let program_data_account = setup_program_data_account(Some(&authority_key));
+
+    let program_key = Pubkey::new_unique();
+    let program_account = setup_program_account(&program_data_key);
+
+    let mut seed = [0u8; SEED_LEN];
+    seed[0..3].copy_from_slice("idl".as_bytes());
+
+    let (metadata_key, _) =
+        Pubkey::find_program_address(&[program_key.as_ref(), &seed], &PROGRAM_ID);
+
+    let initial_data = [1u8; 5];
+    let updated_data = [2u8; 12];
+    let metadata_account = create_funded_account(
+        minimum_balance_for(Header::LEN + updated_data.len()),
+        system_program::ID,
+    );
+
+    process_instructions(
+        &[
+            (
+                &initialize(
+                    &authority_key,
+                    &program_key,
+                    Some(&program_data_key),
+                    InitializeArgs {
+                        canonical: true,
+                        seed,
+                        encoding: 0,
+                        compression: 0,
+                        format: 0,
+                        data_source: 0,
+                    },
+                    Some(&initial_data),
+                )
+                .unwrap(),
+                &[
+                    Check::success(),
+                    // metadata data
+                    Check::account(&metadata_key)
+                        .data_slice(Header::LEN, &initial_data)
+                        .build(),
+                ],
+            ),
+            (
+                &set_data(
+                    &metadata_key,
+                    &authority_key,
+                    None,
+                    Some(&program_key),
+                    Some(&program_data_key),
+                    SetDataArgs {
+                        encoding: 1,
+                        compression: 0,
+                        format: 1,
+                        data_source: Some(0),
+                    },
+                    Some(&updated_data),
+                )
+                .unwrap(),
+                &[
+                    Check::success(),
+                    // data length
+                    Check::account(&metadata_key)
+                        .space(Header::LEN + updated_data.len())
+                        .build(),
+                    // metadata data
+                    Check::account(&metadata_key)
+                        .data_slice(Header::LEN, &updated_data)
+                        .build(),
+                ],
+            ),
+        ],
+        &[
+            (metadata_key, metadata_account),
+            (PROGRAM_ID, Account::default()),
+            (authority_key, Account::default()),
+            (program_key, program_account),
+            (program_data_key, program_data_account),
+            keyed_account_for_system_program(),
+        ],
+    );
+}
+
+#[test]
+fn test_set_data_buffer() {
+    let authority_key = Pubkey::new_unique();
+
+    let program_data_key = Pubkey::new_unique();
+    let program_data_account = setup_program_data_account(Some(&authority_key));
+
+    let program_key = Pubkey::new_unique();
+    let program_account = setup_program_account(&program_data_key);
+
+    let mut seed = [0u8; SEED_LEN];
+    seed[0..3].copy_from_slice("idl".as_bytes());
+
+    let (metadata_key, _) =
+        Pubkey::find_program_address(&[program_key.as_ref(), &seed], &PROGRAM_ID);
+
+    let buffer_key = Pubkey::new_unique();
+    let initial_data = [1u8; 5];
+    let updated_data = [3u8; 9];
+
+    let metadata_account = create_funded_account(
+        minimum_balance_for(Header::LEN + updated_data.len()),
+        system_program::ID,
+    );
+    let buffer_account = create_funded_account(
+        minimum_balance_for(Buffer::LEN + updated_data.len()),
+        system_program::ID,
+    );
+
+    process_instructions(
+        &[
+            (
+                &initialize(
+                    &authority_key,
+                    &program_key,
+                    Some(&program_data_key),
+                    InitializeArgs {
+                        canonical: true,
+                        seed,
+                        encoding: 0,
+                        compression: 0,
+                        format: 0,
+                        data_source: 0,
+                    },
+                    Some(&initial_data),
+                )
+                .unwrap(),
+                &[
+                    Check::success(),
+                    // metadata data
+                    Check::account(&metadata_key)
+                        .data_slice(Header::LEN, &initial_data)
+                        .build(),
+                ],
+            ),
+            (
+                &allocate(&buffer_key, &buffer_key, None, None, None).unwrap(),
+                &[
+                    Check::success(),
+                    // account discriminator
+                    Check::account(&buffer_key).data_slice(0, &[1]).build(),
+                ],
+            ),
+            (
+                &write(&buffer_key, &buffer_key, None, 0, &updated_data).unwrap(),
+                &[
+                    Check::success(),
+                    // buffer data
+                    Check::account(&buffer_key)
+                        .data_slice(Buffer::LEN, &updated_data)
+                        .build(),
+                ],
+            ),
+            (
+                &set_data(
+                    &metadata_key,
+                    &authority_key,
+                    Some(&buffer_key),
+                    Some(&program_key),
+                    Some(&program_data_key),
+                    SetDataArgs {
+                        encoding: 0,
+                        compression: 0,
+                        format: 0,
+                        data_source: Some(0),
+                    },
+                    None,
+                )
+                .unwrap(),
+                &[
+                    Check::success(),
+                    // data length
+                    Check::account(&metadata_key)
+                        .space(Header::LEN + updated_data.len())
+                        .build(),
+                    // metadata data
+                    Check::account(&metadata_key)
+                        .data_slice(Header::LEN, &updated_data)
+                        .build(),
+                ],
+            ),
+        ],
+        &[
+            (metadata_key, metadata_account),
+            (buffer_key, buffer_account),
+            (PROGRAM_ID, Account::default()),
+            (authority_key, Account::default()),
+            (program_key, program_account),
+            (program_data_key, program_data_account),
+            keyed_account_for_system_program(),
+        ],
+    );
+}
+
+#[test]
+fn fail_set_data_with_wrong_authority() {
+    let authority_key = Pubkey::new_unique();
+    let wrong_authority_key = Pubkey::new_unique();
+
+    let program_data_key = Pubkey::new_unique();
+    let program_data_account = setup_program_data_account(Some(&authority_key));
+
+    let program_key = Pubkey::new_unique();
+    let program_account = setup_program_account(&program_data_key);
+
+    let mut seed = [0u8; SEED_LEN];
+    seed[0..3].copy_from_slice("idl".as_bytes());
+
+    let (metadata_key, _) =
+        Pubkey::find_program_address(&[program_key.as_ref(), &seed], &PROGRAM_ID);
+    let data = [1u8; 5];
+    let metadata_account = create_funded_account(
+        minimum_balance_for(Header::LEN + data.len()),
+        system_program::ID,
+    );
+
+    process_instructions(
+        &[
+            (
+                &initialize(
+                    &authority_key,
+                    &program_key,
+                    Some(&program_data_key),
+                    InitializeArgs {
+                        canonical: true,
+                        seed,
+                        encoding: 0,
+                        compression: 0,
+                        format: 0,
+                        data_source: 0,
+                    },
+                    Some(&data),
+                )
+                .unwrap(),
+                &[Check::success()],
+            ),
+            (
+                &set_data(
+                    &metadata_key,
+                    &wrong_authority_key,
+                    None,
+                    Some(&program_key),
+                    Some(&program_data_key),
+                    SetDataArgs {
+                        encoding: 0,
+                        compression: 0,
+                        format: 0,
+                        data_source: Some(0),
+                    },
+                    Some(&[2u8; 5]),
+                )
+                .unwrap(),
+                &[Check::err(ProgramError::IncorrectAuthority)],
+            ),
+        ],
+        &[
+            (metadata_key, metadata_account),
+            (PROGRAM_ID, Account::default()),
+            (authority_key, Account::default()),
+            (wrong_authority_key, Account::default()),
+            (program_key, program_account),
+            (program_data_key, program_data_account),
+            keyed_account_for_system_program(),
+        ],
+    );
+}
+
+#[test]
+fn fail_set_data_from_empty_buffer_as_direct_data() {
+    let authority_key = Pubkey::new_unique();
+
+    let program_data_key = Pubkey::new_unique();
+    let program_data_account = setup_program_data_account(Some(&authority_key));
+
+    let program_key = Pubkey::new_unique();
+    let program_account = setup_program_account(&program_data_key);
+
+    let mut seed = [0u8; SEED_LEN];
+    seed[0..3].copy_from_slice("idl".as_bytes());
+
+    let (metadata_key, _) =
+        Pubkey::find_program_address(&[program_key.as_ref(), &seed], &PROGRAM_ID);
+    let buffer_key = Pubkey::new_unique();
+    let data = [1u8; 5];
+
+    let metadata_account = create_funded_account(
+        minimum_balance_for(Header::LEN + data.len()),
+        system_program::ID,
+    );
+    let buffer_account =
+        create_funded_account(minimum_balance_for(Buffer::LEN), system_program::ID);
+
+    process_instructions(
+        &[
+            (
+                &initialize(
+                    &authority_key,
+                    &program_key,
+                    Some(&program_data_key),
+                    InitializeArgs {
+                        canonical: true,
+                        seed,
+                        encoding: 0,
+                        compression: 0,
+                        format: 0,
+                        data_source: 0,
+                    },
+                    Some(&data),
+                )
+                .unwrap(),
+                &[Check::success()],
+            ),
+            (
+                &allocate(&buffer_key, &buffer_key, None, None, None).unwrap(),
+                &[Check::success()],
+            ),
+            (
+                &set_data(
+                    &metadata_key,
+                    &authority_key,
+                    Some(&buffer_key),
+                    Some(&program_key),
+                    Some(&program_data_key),
+                    SetDataArgs {
+                        encoding: 0,
+                        compression: 0,
+                        format: 0,
+                        data_source: Some(0),
+                    },
+                    None,
+                )
+                .unwrap(),
+                &[Check::err(ProgramError::Custom(
+                    ProgramMetadataError::InvalidDataLength as u32,
+                ))],
+            ),
+        ],
+        &[
+            (metadata_key, metadata_account),
+            (buffer_key, buffer_account),
+            (PROGRAM_ID, Account::default()),
+            (authority_key, Account::default()),
+            (program_key, program_account),
+            (program_data_key, program_data_account),
+            keyed_account_for_system_program(),
+        ],
+    );
+}
+
+#[test]
+fn fail_set_data_from_wrong_owner_buffer() {
+    let authority_key = Pubkey::new_unique();
+
+    let program_data_key = Pubkey::new_unique();
+    let program_data_account = setup_program_data_account(Some(&authority_key));
+
+    let program_key = Pubkey::new_unique();
+    let program_account = setup_program_account(&program_data_key);
+
+    let mut seed = [0u8; SEED_LEN];
+    seed[0..3].copy_from_slice("idl".as_bytes());
+
+    let (metadata_key, _) =
+        Pubkey::find_program_address(&[program_key.as_ref(), &seed], &PROGRAM_ID);
+    let buffer_key = Pubkey::new_unique();
+    let data = [1u8; 5];
+
+    let metadata_account = create_funded_account(
+        minimum_balance_for(Header::LEN + data.len()),
+        system_program::ID,
+    );
+    let buffer_account =
+        create_funded_account(minimum_balance_for(Buffer::LEN), system_program::ID);
+
+    process_instructions(
+        &[
+            (
+                &initialize(
+                    &authority_key,
+                    &program_key,
+                    Some(&program_data_key),
+                    InitializeArgs {
+                        canonical: true,
+                        seed,
+                        encoding: 0,
+                        compression: 0,
+                        format: 0,
+                        data_source: 0,
+                    },
+                    Some(&data),
+                )
+                .unwrap(),
+                &[Check::success()],
+            ),
+            (
+                &set_data(
+                    &metadata_key,
+                    &authority_key,
+                    Some(&buffer_key),
+                    Some(&program_key),
+                    Some(&program_data_key),
+                    SetDataArgs {
+                        encoding: 0,
+                        compression: 0,
+                        format: 0,
+                        data_source: Some(0),
+                    },
+                    None,
+                )
+                .unwrap(),
+                &[Check::err(ProgramError::InvalidAccountOwner)],
+            ),
+        ],
+        &[
+            (metadata_key, metadata_account),
+            (buffer_key, buffer_account),
+            (PROGRAM_ID, Account::default()),
+            (authority_key, Account::default()),
+            (program_key, program_account),
+            (program_data_key, program_data_account),
+            keyed_account_for_system_program(),
+        ],
+    );
+}
+
+#[test]
+fn fail_set_data_with_invalid_encoding() {
+    let authority_key = Pubkey::new_unique();
+
+    let program_data_key = Pubkey::new_unique();
+    let program_data_account = setup_program_data_account(Some(&authority_key));
+
+    let program_key = Pubkey::new_unique();
+    let program_account = setup_program_account(&program_data_key);
+
+    let mut seed = [0u8; SEED_LEN];
+    seed[0..3].copy_from_slice("idl".as_bytes());
+
+    let (metadata_key, _) =
+        Pubkey::find_program_address(&[program_key.as_ref(), &seed], &PROGRAM_ID);
+    let data = [1u8; 5];
+    let metadata_account = create_funded_account(
+        minimum_balance_for(Header::LEN + data.len()),
+        system_program::ID,
+    );
+
+    process_instructions(
+        &[
+            (
+                &initialize(
+                    &authority_key,
+                    &program_key,
+                    Some(&program_data_key),
+                    InitializeArgs {
+                        canonical: true,
+                        seed,
+                        encoding: 0,
+                        compression: 0,
+                        format: 0,
+                        data_source: 0,
+                    },
+                    Some(&data),
+                )
+                .unwrap(),
+                &[Check::success()],
+            ),
+            (
+                &set_data(
+                    &metadata_key,
+                    &authority_key,
+                    None,
+                    Some(&program_key),
+                    Some(&program_data_key),
+                    SetDataArgs {
+                        encoding: 99,
+                        compression: 0,
+                        format: 0,
+                        data_source: None,
+                    },
+                    None,
+                )
+                .unwrap(),
+                &[Check::err(ProgramError::InvalidAccountData)],
+            ),
+        ],
+        &[
+            (metadata_key, metadata_account),
+            (PROGRAM_ID, Account::default()),
+            (authority_key, Account::default()),
+            (program_key, program_account),
+            (program_data_key, program_data_account),
+            keyed_account_for_system_program(),
+        ],
+    );
+}

--- a/program/tests/set_data.rs
+++ b/program/tests/set_data.rs
@@ -50,8 +50,7 @@ fn test_set_data_instruction_data() {
                         data_source: 0,
                     },
                     Some(&initial_data),
-                )
-                .unwrap(),
+                ),
                 &[
                     Check::success(),
                     // metadata data
@@ -74,8 +73,7 @@ fn test_set_data_instruction_data() {
                         data_source: Some(0),
                     },
                     Some(&updated_data),
-                )
-                .unwrap(),
+                ),
                 &[
                     Check::success(),
                     // data length
@@ -145,8 +143,7 @@ fn test_set_data_buffer() {
                         data_source: 0,
                     },
                     Some(&initial_data),
-                )
-                .unwrap(),
+                ),
                 &[
                     Check::success(),
                     // metadata data
@@ -156,7 +153,7 @@ fn test_set_data_buffer() {
                 ],
             ),
             (
-                &allocate(&buffer_key, &buffer_key, None, None, None).unwrap(),
+                &allocate(&buffer_key, &buffer_key, None, None, None),
                 &[
                     Check::success(),
                     // account discriminator
@@ -164,7 +161,7 @@ fn test_set_data_buffer() {
                 ],
             ),
             (
-                &write(&buffer_key, &buffer_key, None, 0, &updated_data).unwrap(),
+                &write(&buffer_key, &buffer_key, None, 0, &updated_data),
                 &[
                     Check::success(),
                     // buffer data
@@ -187,8 +184,7 @@ fn test_set_data_buffer() {
                         data_source: Some(0),
                     },
                     None,
-                )
-                .unwrap(),
+                ),
                 &[
                     Check::success(),
                     // data length
@@ -252,8 +248,7 @@ fn test_set_data_without_replacing_data() {
                         data_source: 0,
                     },
                     Some(&data),
-                )
-                .unwrap(),
+                ),
                 &[Check::success()],
             ),
             (
@@ -270,8 +265,7 @@ fn test_set_data_without_replacing_data() {
                         data_source: None,
                     },
                     None,
-                )
-                .unwrap(),
+                ),
                 &[
                     Check::success(),
                     Check::account(&metadata_key)
@@ -334,8 +328,7 @@ fn test_set_data_shrinks_metadata_account() {
                         data_source: 0,
                     },
                     Some(&initial_data),
-                )
-                .unwrap(),
+                ),
                 &[Check::success()],
             ),
             (
@@ -352,8 +345,7 @@ fn test_set_data_shrinks_metadata_account() {
                         data_source: Some(0),
                     },
                     Some(&updated_data),
-                )
-                .unwrap(),
+                ),
                 &[
                     Check::success(),
                     Check::account(&metadata_key)
@@ -414,8 +406,7 @@ fn fail_set_data_with_wrong_authority() {
                         data_source: 0,
                     },
                     Some(&data),
-                )
-                .unwrap(),
+                ),
                 &[Check::success()],
             ),
             (
@@ -432,8 +423,7 @@ fn fail_set_data_with_wrong_authority() {
                         data_source: Some(0),
                     },
                     Some(&[2u8; 5]),
-                )
-                .unwrap(),
+                ),
                 &[Check::err(ProgramError::IncorrectAuthority)],
             ),
         ],
@@ -490,12 +480,11 @@ fn fail_set_data_from_empty_buffer_as_direct_data() {
                         data_source: 0,
                     },
                     Some(&data),
-                )
-                .unwrap(),
+                ),
                 &[Check::success()],
             ),
             (
-                &allocate(&buffer_key, &buffer_key, None, None, None).unwrap(),
+                &allocate(&buffer_key, &buffer_key, None, None, None),
                 &[Check::success()],
             ),
             (
@@ -512,8 +501,7 @@ fn fail_set_data_from_empty_buffer_as_direct_data() {
                         data_source: Some(0),
                     },
                     None,
-                )
-                .unwrap(),
+                ),
                 &[Check::err(ProgramError::Custom(
                     ProgramMetadataError::InvalidDataLength as u32,
                 ))],
@@ -569,8 +557,7 @@ fn fail_set_data_with_invalid_compression() {
                         data_source: 0,
                     },
                     Some(&data),
-                )
-                .unwrap(),
+                ),
                 &[Check::success()],
             ),
             (
@@ -587,8 +574,7 @@ fn fail_set_data_with_invalid_compression() {
                         data_source: None,
                     },
                     None,
-                )
-                .unwrap(),
+                ),
                 &[Check::err(ProgramError::InvalidInstructionData)],
             ),
         ],
@@ -641,8 +627,7 @@ fn fail_set_data_with_invalid_data_source() {
                         data_source: 0,
                     },
                     Some(&data),
-                )
-                .unwrap(),
+                ),
                 &[Check::success()],
             ),
             (
@@ -659,8 +644,7 @@ fn fail_set_data_with_invalid_data_source() {
                         data_source: Some(99), // <- invalid data source
                     },
                     Some(&[2u8; 5]),
-                )
-                .unwrap(),
+                ),
                 &[Check::err(ProgramError::InvalidInstructionData)],
             ),
         ],
@@ -716,8 +700,7 @@ fn fail_set_data_from_wrong_owner_buffer() {
                         data_source: 0,
                     },
                     Some(&data),
-                )
-                .unwrap(),
+                ),
                 &[Check::success()],
             ),
             (
@@ -734,8 +717,7 @@ fn fail_set_data_from_wrong_owner_buffer() {
                         data_source: Some(0),
                     },
                     None,
-                )
-                .unwrap(),
+                ),
                 &[Check::err(ProgramError::InvalidAccountOwner)],
             ),
         ],
@@ -788,8 +770,7 @@ fn fail_set_data_with_invalid_encoding() {
                         data_source: 0,
                     },
                     Some(&data),
-                )
-                .unwrap(),
+                ),
                 &[Check::success()],
             ),
             (
@@ -806,8 +787,7 @@ fn fail_set_data_with_invalid_encoding() {
                         data_source: None,
                     },
                     None,
-                )
-                .unwrap(),
+                ),
                 &[Check::err(ProgramError::InvalidInstructionData)],
             ),
         ],

--- a/program/tests/set_immutable.rs
+++ b/program/tests/set_immutable.rs
@@ -49,8 +49,7 @@ fn test_set_immutable_canonical() {
                         data_source: 0,
                     },
                     Some(&data),
-                )
-                .unwrap(),
+                ),
                 &[Check::success()],
             ),
             (
@@ -59,8 +58,7 @@ fn test_set_immutable_canonical() {
                     &authority_key,
                     Some(&program_key),
                     Some(&program_data_key),
-                )
-                .unwrap(),
+                ),
                 &[Check::success()],
             ),
             (
@@ -77,8 +75,7 @@ fn test_set_immutable_canonical() {
                         data_source: Some(0),
                     },
                     Some(&[2u8; 6]),
-                )
-                .unwrap(),
+                ),
                 &[Check::err(ProgramError::Custom(
                     ProgramMetadataError::ImmutableMetadataAccount as u32,
                 ))],
@@ -135,12 +132,11 @@ fn test_set_immutable_non_canonical() {
                         data_source: 0,
                     },
                     Some(&data),
-                )
-                .unwrap(),
+                ),
                 &[Check::success()],
             ),
             (
-                &set_immutable(&metadata_key, &authority_key, None, None).unwrap(),
+                &set_immutable(&metadata_key, &authority_key, None, None),
                 &[Check::success()],
             ),
             (
@@ -157,8 +153,7 @@ fn test_set_immutable_non_canonical() {
                         data_source: Some(0),
                     },
                     Some(&[2u8; 6]),
-                )
-                .unwrap(),
+                ),
                 &[Check::err(ProgramError::Custom(
                     ProgramMetadataError::ImmutableMetadataAccount as u32,
                 ))],
@@ -214,8 +209,7 @@ fn fail_set_immutable_with_wrong_authority() {
                         data_source: 0,
                     },
                     Some(&data),
-                )
-                .unwrap(),
+                ),
                 &[Check::success()],
             ),
             (
@@ -224,8 +218,7 @@ fn fail_set_immutable_with_wrong_authority() {
                     &wrong_authority_key,
                     Some(&program_key),
                     Some(&program_data_key),
-                )
-                .unwrap(),
+                ),
                 &[Check::err(ProgramError::IncorrectAuthority)],
             ),
         ],
@@ -250,11 +243,11 @@ fn fail_set_immutable_buffer_account() {
     process_instructions(
         &[
             (
-                &allocate(&buffer_key, &buffer_key, None, None, None).unwrap(),
+                &allocate(&buffer_key, &buffer_key, None, None, None),
                 &[Check::success()],
             ),
             (
-                &set_immutable(&buffer_key, &buffer_key, None, None).unwrap(),
+                &set_immutable(&buffer_key, &buffer_key, None, None),
                 &[Check::err(ProgramError::UninitializedAccount)],
             ),
         ],
@@ -304,8 +297,7 @@ fn fail_set_immutable_twice() {
                         data_source: 0,
                     },
                     Some(&data),
-                )
-                .unwrap(),
+                ),
                 &[Check::success()],
             ),
             (
@@ -314,8 +306,7 @@ fn fail_set_immutable_twice() {
                     &authority_key,
                     Some(&program_key),
                     Some(&program_data_key),
-                )
-                .unwrap(),
+                ),
                 &[Check::success()],
             ),
             (
@@ -324,8 +315,7 @@ fn fail_set_immutable_twice() {
                     &authority_key,
                     Some(&program_key),
                     Some(&program_data_key),
-                )
-                .unwrap(),
+                ),
                 &[Check::err(ProgramError::Custom(
                     ProgramMetadataError::ImmutableMetadataAccount as u32,
                 ))],

--- a/program/tests/set_immutable.rs
+++ b/program/tests/set_immutable.rs
@@ -1,0 +1,343 @@
+mod setup;
+pub use setup::*;
+
+use mollusk_svm::{program::keyed_account_for_system_program, result::Check};
+use solana_account::Account;
+use solana_program_error::ProgramError;
+use solana_pubkey::Pubkey;
+use solana_sdk_ids::system_program;
+use spl_program_metadata::{
+    error::ProgramMetadataError,
+    state::{buffer::Buffer, header::Header, SEED_LEN},
+};
+
+#[test]
+fn test_set_immutable_canonical() {
+    let authority_key = Pubkey::new_unique();
+
+    let program_data_key = Pubkey::new_unique();
+    let program_data_account = setup_program_data_account(Some(&authority_key));
+
+    let program_key = Pubkey::new_unique();
+    let program_account = setup_program_account(&program_data_key);
+
+    let mut seed = [0u8; SEED_LEN];
+    seed[0..3].copy_from_slice("idl".as_bytes());
+
+    let (metadata_key, _) =
+        Pubkey::find_program_address(&[program_key.as_ref(), &seed], &PROGRAM_ID);
+
+    let data = [1u8; 6];
+    let metadata_account = create_funded_account(
+        minimum_balance_for(Header::LEN + data.len()),
+        system_program::ID,
+    );
+
+    process_instructions(
+        &[
+            (
+                &initialize(
+                    &authority_key,
+                    &program_key,
+                    Some(&program_data_key),
+                    InitializeArgs {
+                        canonical: true,
+                        seed,
+                        encoding: 0,
+                        compression: 0,
+                        format: 0,
+                        data_source: 0,
+                    },
+                    Some(&data),
+                )
+                .unwrap(),
+                &[Check::success()],
+            ),
+            (
+                &set_immutable(
+                    &metadata_key,
+                    &authority_key,
+                    Some(&program_key),
+                    Some(&program_data_key),
+                )
+                .unwrap(),
+                &[Check::success()],
+            ),
+            (
+                &set_data(
+                    &metadata_key,
+                    &authority_key,
+                    None,
+                    Some(&program_key),
+                    Some(&program_data_key),
+                    SetDataArgs {
+                        encoding: 0,
+                        compression: 0,
+                        format: 0,
+                        data_source: Some(0),
+                    },
+                    Some(&[2u8; 6]),
+                )
+                .unwrap(),
+                &[Check::err(ProgramError::Custom(
+                    ProgramMetadataError::ImmutableMetadataAccount as u32,
+                ))],
+            ),
+        ],
+        &[
+            (metadata_key, metadata_account),
+            (PROGRAM_ID, Account::default()),
+            (authority_key, Account::default()),
+            (program_key, program_account),
+            (program_data_key, program_data_account),
+            keyed_account_for_system_program(),
+        ],
+    );
+}
+
+#[test]
+fn test_set_immutable_non_canonical() {
+    let authority_key = Pubkey::new_unique();
+
+    let program_data_key = Pubkey::new_unique();
+    let program_data_account = setup_program_data_account(Some(&authority_key));
+
+    let program_key = Pubkey::new_unique();
+    let program_account = setup_program_account(&program_data_key);
+
+    let mut seed = [0u8; SEED_LEN];
+    seed[0..3].copy_from_slice("idl".as_bytes());
+
+    let (metadata_key, _) = Pubkey::find_program_address(
+        &[program_key.as_ref(), authority_key.as_ref(), &seed],
+        &PROGRAM_ID,
+    );
+
+    let data = [1u8; 6];
+    let metadata_account = create_funded_account(
+        minimum_balance_for(Header::LEN + data.len()),
+        system_program::ID,
+    );
+
+    process_instructions(
+        &[
+            (
+                &initialize(
+                    &authority_key,
+                    &program_key,
+                    None,
+                    InitializeArgs {
+                        canonical: false,
+                        seed,
+                        encoding: 0,
+                        compression: 0,
+                        format: 0,
+                        data_source: 0,
+                    },
+                    Some(&data),
+                )
+                .unwrap(),
+                &[Check::success()],
+            ),
+            (
+                &set_immutable(&metadata_key, &authority_key, None, None).unwrap(),
+                &[Check::success()],
+            ),
+            (
+                &set_data(
+                    &metadata_key,
+                    &authority_key,
+                    None,
+                    None,
+                    None,
+                    SetDataArgs {
+                        encoding: 0,
+                        compression: 0,
+                        format: 0,
+                        data_source: Some(0),
+                    },
+                    Some(&[2u8; 6]),
+                )
+                .unwrap(),
+                &[Check::err(ProgramError::Custom(
+                    ProgramMetadataError::ImmutableMetadataAccount as u32,
+                ))],
+            ),
+        ],
+        &[
+            (metadata_key, metadata_account),
+            (PROGRAM_ID, Account::default()),
+            (authority_key, Account::default()),
+            (program_key, program_account),
+            (program_data_key, program_data_account),
+            keyed_account_for_system_program(),
+        ],
+    );
+}
+
+#[test]
+fn fail_set_immutable_with_wrong_authority() {
+    let authority_key = Pubkey::new_unique();
+    let wrong_authority_key = Pubkey::new_unique();
+
+    let program_data_key = Pubkey::new_unique();
+    let program_data_account = setup_program_data_account(Some(&authority_key));
+
+    let program_key = Pubkey::new_unique();
+    let program_account = setup_program_account(&program_data_key);
+
+    let mut seed = [0u8; SEED_LEN];
+    seed[0..3].copy_from_slice("idl".as_bytes());
+
+    let (metadata_key, _) =
+        Pubkey::find_program_address(&[program_key.as_ref(), &seed], &PROGRAM_ID);
+
+    let data = [1u8; 6];
+    let metadata_account = create_funded_account(
+        minimum_balance_for(Header::LEN + data.len()),
+        system_program::ID,
+    );
+
+    process_instructions(
+        &[
+            (
+                &initialize(
+                    &authority_key,
+                    &program_key,
+                    Some(&program_data_key),
+                    InitializeArgs {
+                        canonical: true,
+                        seed,
+                        encoding: 0,
+                        compression: 0,
+                        format: 0,
+                        data_source: 0,
+                    },
+                    Some(&data),
+                )
+                .unwrap(),
+                &[Check::success()],
+            ),
+            (
+                &set_immutable(
+                    &metadata_key,
+                    &wrong_authority_key,
+                    Some(&program_key),
+                    Some(&program_data_key),
+                )
+                .unwrap(),
+                &[Check::err(ProgramError::IncorrectAuthority)],
+            ),
+        ],
+        &[
+            (metadata_key, metadata_account),
+            (PROGRAM_ID, Account::default()),
+            (authority_key, Account::default()),
+            (wrong_authority_key, Account::default()),
+            (program_key, program_account),
+            (program_data_key, program_data_account),
+            keyed_account_for_system_program(),
+        ],
+    );
+}
+
+#[test]
+fn fail_set_immutable_buffer_account() {
+    let buffer_key = Pubkey::new_unique();
+    let buffer_account =
+        create_funded_account(minimum_balance_for(Buffer::LEN), system_program::ID);
+
+    process_instructions(
+        &[
+            (
+                &allocate(&buffer_key, &buffer_key, None, None, None).unwrap(),
+                &[Check::success()],
+            ),
+            (
+                &set_immutable(&buffer_key, &buffer_key, None, None).unwrap(),
+                &[Check::err(ProgramError::UninitializedAccount)],
+            ),
+        ],
+        &[
+            (buffer_key, buffer_account),
+            (PROGRAM_ID, Account::default()),
+            keyed_account_for_system_program(),
+        ],
+    );
+}
+
+#[test]
+fn fail_set_immutable_twice() {
+    let authority_key = Pubkey::new_unique();
+
+    let program_data_key = Pubkey::new_unique();
+    let program_data_account = setup_program_data_account(Some(&authority_key));
+
+    let program_key = Pubkey::new_unique();
+    let program_account = setup_program_account(&program_data_key);
+
+    let mut seed = [0u8; SEED_LEN];
+    seed[0..3].copy_from_slice("idl".as_bytes());
+
+    let (metadata_key, _) =
+        Pubkey::find_program_address(&[program_key.as_ref(), &seed], &PROGRAM_ID);
+
+    let data = [1u8; 6];
+    let metadata_account = create_funded_account(
+        minimum_balance_for(Header::LEN + data.len()),
+        system_program::ID,
+    );
+
+    process_instructions(
+        &[
+            (
+                &initialize(
+                    &authority_key,
+                    &program_key,
+                    Some(&program_data_key),
+                    InitializeArgs {
+                        canonical: true,
+                        seed,
+                        encoding: 0,
+                        compression: 0,
+                        format: 0,
+                        data_source: 0,
+                    },
+                    Some(&data),
+                )
+                .unwrap(),
+                &[Check::success()],
+            ),
+            (
+                &set_immutable(
+                    &metadata_key,
+                    &authority_key,
+                    Some(&program_key),
+                    Some(&program_data_key),
+                )
+                .unwrap(),
+                &[Check::success()],
+            ),
+            (
+                &set_immutable(
+                    &metadata_key,
+                    &authority_key,
+                    Some(&program_key),
+                    Some(&program_data_key),
+                )
+                .unwrap(),
+                &[Check::err(ProgramError::Custom(
+                    ProgramMetadataError::ImmutableMetadataAccount as u32,
+                ))],
+            ),
+        ],
+        &[
+            (metadata_key, metadata_account),
+            (PROGRAM_ID, Account::default()),
+            (authority_key, Account::default()),
+            (program_key, program_account),
+            (program_data_key, program_data_account),
+            keyed_account_for_system_program(),
+        ],
+    );
+}

--- a/program/tests/setup/allocate.rs
+++ b/program/tests/setup/allocate.rs
@@ -1,5 +1,4 @@
 use solana_instruction::{AccountMeta, Instruction};
-use solana_program_error::ProgramError;
 use solana_pubkey::Pubkey;
 use solana_sdk_ids::system_program;
 use spl_program_metadata::{instruction::ProgramMetadataInstruction, state::SEED_LEN};
@@ -12,7 +11,7 @@ pub fn allocate(
     program: Option<&Pubkey>,
     program_data: Option<&Pubkey>,
     seed: Option<&[u8; SEED_LEN]>,
-) -> Result<Instruction, ProgramError> {
+) -> Instruction {
     let accounts = vec![
         AccountMeta::new(*buffer, false),
         AccountMeta::new_readonly(*authority, true),
@@ -26,9 +25,9 @@ pub fn allocate(
         data.extend_from_slice(seed);
     }
 
-    Ok(Instruction {
+    Instruction {
         program_id: PROGRAM_ID,
         accounts,
         data,
-    })
+    }
 }

--- a/program/tests/setup/close.rs
+++ b/program/tests/setup/close.rs
@@ -1,0 +1,28 @@
+use solana_instruction::{AccountMeta, Instruction};
+use solana_program_error::ProgramError;
+use solana_pubkey::Pubkey;
+use spl_program_metadata::instruction::ProgramMetadataInstruction;
+
+use super::PROGRAM_ID;
+
+pub fn close(
+    account: &Pubkey,
+    authority: &Pubkey,
+    program: Option<&Pubkey>,
+    program_data: Option<&Pubkey>,
+    destination: &Pubkey,
+) -> Result<Instruction, ProgramError> {
+    let accounts = vec![
+        AccountMeta::new(*account, false),
+        AccountMeta::new_readonly(*authority, true),
+        AccountMeta::new_readonly(*program.unwrap_or(&PROGRAM_ID), false),
+        AccountMeta::new_readonly(*program_data.unwrap_or(&PROGRAM_ID), false),
+        AccountMeta::new(*destination, false),
+    ];
+
+    Ok(Instruction {
+        program_id: PROGRAM_ID,
+        accounts,
+        data: vec![ProgramMetadataInstruction::Close as u8],
+    })
+}

--- a/program/tests/setup/close.rs
+++ b/program/tests/setup/close.rs
@@ -1,5 +1,4 @@
 use solana_instruction::{AccountMeta, Instruction};
-use solana_program_error::ProgramError;
 use solana_pubkey::Pubkey;
 use spl_program_metadata::instruction::ProgramMetadataInstruction;
 
@@ -11,7 +10,7 @@ pub fn close(
     program: Option<&Pubkey>,
     program_data: Option<&Pubkey>,
     destination: &Pubkey,
-) -> Result<Instruction, ProgramError> {
+) -> Instruction {
     let accounts = vec![
         AccountMeta::new(*account, false),
         AccountMeta::new_readonly(*authority, true),
@@ -20,9 +19,9 @@ pub fn close(
         AccountMeta::new(*destination, false),
     ];
 
-    Ok(Instruction {
+    Instruction {
         program_id: PROGRAM_ID,
         accounts,
         data: vec![ProgramMetadataInstruction::Close as u8],
-    })
+    }
 }

--- a/program/tests/setup/extend.rs
+++ b/program/tests/setup/extend.rs
@@ -1,5 +1,4 @@
 use solana_instruction::{AccountMeta, Instruction};
-use solana_program_error::ProgramError;
 use solana_pubkey::Pubkey;
 use spl_program_metadata::instruction::ProgramMetadataInstruction;
 
@@ -11,7 +10,7 @@ pub fn extend(
     program: Option<&Pubkey>,
     program_data: Option<&Pubkey>,
     length: u16,
-) -> Result<Instruction, ProgramError> {
+) -> Instruction {
     let accounts = vec![
         AccountMeta::new(*account, false),
         AccountMeta::new_readonly(*authority, true),
@@ -22,9 +21,9 @@ pub fn extend(
     let mut data = vec![ProgramMetadataInstruction::Extend as u8];
     data.extend_from_slice(&length.to_le_bytes());
 
-    Ok(Instruction {
+    Instruction {
         program_id: PROGRAM_ID,
         accounts,
         data,
-    })
+    }
 }

--- a/program/tests/setup/initialize.rs
+++ b/program/tests/setup/initialize.rs
@@ -1,5 +1,4 @@
 use solana_instruction::{AccountMeta, Instruction};
-use solana_program_error::ProgramError;
 use solana_pubkey::Pubkey;
 use solana_sdk_ids::system_program;
 
@@ -11,7 +10,7 @@ pub fn initialize(
     program_data: Option<&Pubkey>,
     args: InitializeArgs,
     instruction_data: Option<&[u8]>,
-) -> Result<Instruction, ProgramError> {
+) -> Instruction {
     let seeds: &[&[u8]] = if args.canonical {
         &[program.as_ref(), args.seed.as_ref()]
     } else {
@@ -39,11 +38,11 @@ pub fn initialize(
         data.extend_from_slice(instruction_data);
     }
 
-    Ok(Instruction {
+    Instruction {
         program_id: PROGRAM_ID,
         accounts,
         data,
-    })
+    }
 }
 
 pub struct InitializeArgs {

--- a/program/tests/setup/mod.rs
+++ b/program/tests/setup/mod.rs
@@ -1,12 +1,20 @@
 mod allocate;
+mod close;
 mod extend;
 mod initialize;
+mod set_authority;
+mod set_data;
+mod set_immutable;
 mod trim;
 mod write;
 
 pub use allocate::*;
+pub use close::*;
 pub use extend::*;
 pub use initialize::*;
+pub use set_authority::*;
+pub use set_data::*;
+pub use set_immutable::*;
 pub use trim::*;
 pub use write::*;
 

--- a/program/tests/setup/set_authority.rs
+++ b/program/tests/setup/set_authority.rs
@@ -1,0 +1,35 @@
+use solana_instruction::{AccountMeta, Instruction};
+use solana_program_error::ProgramError;
+use solana_pubkey::Pubkey;
+use spl_program_metadata::instruction::ProgramMetadataInstruction;
+
+use super::PROGRAM_ID;
+
+pub fn set_authority(
+    account: &Pubkey,
+    authority: &Pubkey,
+    program: Option<&Pubkey>,
+    program_data: Option<&Pubkey>,
+    new_authority: Option<&Pubkey>,
+) -> Result<Instruction, ProgramError> {
+    let accounts = vec![
+        AccountMeta::new(*account, false),
+        AccountMeta::new_readonly(*authority, true),
+        AccountMeta::new_readonly(*program.unwrap_or(&PROGRAM_ID), false),
+        AccountMeta::new_readonly(*program_data.unwrap_or(&PROGRAM_ID), false),
+    ];
+
+    let mut data = vec![
+        ProgramMetadataInstruction::SetAuthority as u8,
+        new_authority.is_some() as u8,
+    ];
+    if let Some(new_authority) = new_authority {
+        data.extend_from_slice(new_authority.as_ref());
+    }
+
+    Ok(Instruction {
+        program_id: PROGRAM_ID,
+        accounts,
+        data,
+    })
+}

--- a/program/tests/setup/set_authority.rs
+++ b/program/tests/setup/set_authority.rs
@@ -1,5 +1,4 @@
 use solana_instruction::{AccountMeta, Instruction};
-use solana_program_error::ProgramError;
 use solana_pubkey::Pubkey;
 use spl_program_metadata::instruction::ProgramMetadataInstruction;
 
@@ -11,7 +10,7 @@ pub fn set_authority(
     program: Option<&Pubkey>,
     program_data: Option<&Pubkey>,
     new_authority: Option<&Pubkey>,
-) -> Result<Instruction, ProgramError> {
+) -> Instruction {
     let accounts = vec![
         AccountMeta::new(*account, false),
         AccountMeta::new_readonly(*authority, true),
@@ -27,9 +26,9 @@ pub fn set_authority(
         data.extend_from_slice(new_authority.as_ref());
     }
 
-    Ok(Instruction {
+    Instruction {
         program_id: PROGRAM_ID,
         accounts,
         data,
-    })
+    }
 }

--- a/program/tests/setup/set_data.rs
+++ b/program/tests/setup/set_data.rs
@@ -1,0 +1,51 @@
+use solana_instruction::{AccountMeta, Instruction};
+use solana_program_error::ProgramError;
+use solana_pubkey::Pubkey;
+use spl_program_metadata::instruction::ProgramMetadataInstruction;
+
+use super::PROGRAM_ID;
+
+pub fn set_data(
+    metadata: &Pubkey,
+    authority: &Pubkey,
+    buffer: Option<&Pubkey>,
+    program: Option<&Pubkey>,
+    program_data: Option<&Pubkey>,
+    args: SetDataArgs,
+    instruction_data: Option<&[u8]>,
+) -> Result<Instruction, ProgramError> {
+    let accounts = vec![
+        AccountMeta::new(*metadata, false),
+        AccountMeta::new_readonly(*authority, true),
+        AccountMeta::new_readonly(*buffer.unwrap_or(&PROGRAM_ID), false),
+        AccountMeta::new_readonly(*program.unwrap_or(&PROGRAM_ID), false),
+        AccountMeta::new_readonly(*program_data.unwrap_or(&PROGRAM_ID), false),
+    ];
+
+    let mut data = vec![
+        ProgramMetadataInstruction::SetData as u8,
+        args.encoding,
+        args.compression,
+        args.format,
+    ];
+
+    if let Some(data_source) = args.data_source {
+        data.push(data_source);
+        if let Some(instruction_data) = instruction_data {
+            data.extend_from_slice(instruction_data);
+        }
+    }
+
+    Ok(Instruction {
+        program_id: PROGRAM_ID,
+        accounts,
+        data,
+    })
+}
+
+pub struct SetDataArgs {
+    pub encoding: u8,
+    pub compression: u8,
+    pub format: u8,
+    pub data_source: Option<u8>,
+}

--- a/program/tests/setup/set_data.rs
+++ b/program/tests/setup/set_data.rs
@@ -1,5 +1,4 @@
 use solana_instruction::{AccountMeta, Instruction};
-use solana_program_error::ProgramError;
 use solana_pubkey::Pubkey;
 use spl_program_metadata::instruction::ProgramMetadataInstruction;
 
@@ -13,7 +12,7 @@ pub fn set_data(
     program_data: Option<&Pubkey>,
     args: SetDataArgs,
     instruction_data: Option<&[u8]>,
-) -> Result<Instruction, ProgramError> {
+) -> Instruction {
     let accounts = vec![
         AccountMeta::new(*metadata, false),
         AccountMeta::new_readonly(*authority, true),
@@ -36,11 +35,11 @@ pub fn set_data(
         }
     }
 
-    Ok(Instruction {
+    Instruction {
         program_id: PROGRAM_ID,
         accounts,
         data,
-    })
+    }
 }
 
 pub struct SetDataArgs {

--- a/program/tests/setup/set_immutable.rs
+++ b/program/tests/setup/set_immutable.rs
@@ -1,5 +1,4 @@
 use solana_instruction::{AccountMeta, Instruction};
-use solana_program_error::ProgramError;
 use solana_pubkey::Pubkey;
 use spl_program_metadata::instruction::ProgramMetadataInstruction;
 
@@ -10,7 +9,7 @@ pub fn set_immutable(
     authority: &Pubkey,
     program: Option<&Pubkey>,
     program_data: Option<&Pubkey>,
-) -> Result<Instruction, ProgramError> {
+) -> Instruction {
     let accounts = vec![
         AccountMeta::new(*metadata, false),
         AccountMeta::new_readonly(*authority, true),
@@ -18,9 +17,9 @@ pub fn set_immutable(
         AccountMeta::new_readonly(*program_data.unwrap_or(&PROGRAM_ID), false),
     ];
 
-    Ok(Instruction {
+    Instruction {
         program_id: PROGRAM_ID,
         accounts,
         data: vec![ProgramMetadataInstruction::SetImmutable as u8],
-    })
+    }
 }

--- a/program/tests/setup/set_immutable.rs
+++ b/program/tests/setup/set_immutable.rs
@@ -1,0 +1,26 @@
+use solana_instruction::{AccountMeta, Instruction};
+use solana_program_error::ProgramError;
+use solana_pubkey::Pubkey;
+use spl_program_metadata::instruction::ProgramMetadataInstruction;
+
+use super::PROGRAM_ID;
+
+pub fn set_immutable(
+    metadata: &Pubkey,
+    authority: &Pubkey,
+    program: Option<&Pubkey>,
+    program_data: Option<&Pubkey>,
+) -> Result<Instruction, ProgramError> {
+    let accounts = vec![
+        AccountMeta::new(*metadata, false),
+        AccountMeta::new_readonly(*authority, true),
+        AccountMeta::new_readonly(*program.unwrap_or(&PROGRAM_ID), false),
+        AccountMeta::new_readonly(*program_data.unwrap_or(&PROGRAM_ID), false),
+    ];
+
+    Ok(Instruction {
+        program_id: PROGRAM_ID,
+        accounts,
+        data: vec![ProgramMetadataInstruction::SetImmutable as u8],
+    })
+}

--- a/program/tests/setup/trim.rs
+++ b/program/tests/setup/trim.rs
@@ -1,5 +1,4 @@
 use solana_instruction::{AccountMeta, Instruction};
-use solana_program_error::ProgramError;
 use solana_pubkey::Pubkey;
 use solana_sdk_ids::sysvar::rent;
 use spl_program_metadata::instruction::ProgramMetadataInstruction;
@@ -12,7 +11,7 @@ pub fn trim(
     program: Option<&Pubkey>,
     program_data: Option<&Pubkey>,
     destination: &Pubkey,
-) -> Result<Instruction, ProgramError> {
+) -> Instruction {
     let accounts = vec![
         AccountMeta::new(*account, false),
         AccountMeta::new_readonly(*authority, true),
@@ -22,9 +21,9 @@ pub fn trim(
         AccountMeta::new_readonly(rent::ID, false),
     ];
 
-    Ok(Instruction {
+    Instruction {
         program_id: PROGRAM_ID,
         accounts,
         data: vec![ProgramMetadataInstruction::Trim as u8],
-    })
+    }
 }

--- a/program/tests/setup/write.rs
+++ b/program/tests/setup/write.rs
@@ -8,12 +8,14 @@ use super::PROGRAM_ID;
 pub fn write(
     buffer: &Pubkey,
     authority: &Pubkey,
+    source_buffer: Option<&Pubkey>,
     offset: u32,
     data: &[u8],
 ) -> Result<Instruction, ProgramError> {
     let accounts = vec![
         AccountMeta::new(*buffer, false),
         AccountMeta::new_readonly(*authority, true),
+        AccountMeta::new_readonly(*source_buffer.unwrap_or(&PROGRAM_ID), false),
     ];
 
     let mut instruction_data = vec![ProgramMetadataInstruction::Write as u8];

--- a/program/tests/setup/write.rs
+++ b/program/tests/setup/write.rs
@@ -1,5 +1,4 @@
 use solana_instruction::{AccountMeta, Instruction};
-use solana_program_error::ProgramError;
 use solana_pubkey::Pubkey;
 use spl_program_metadata::instruction::ProgramMetadataInstruction;
 
@@ -11,7 +10,7 @@ pub fn write(
     source_buffer: Option<&Pubkey>,
     offset: u32,
     data: &[u8],
-) -> Result<Instruction, ProgramError> {
+) -> Instruction {
     let accounts = vec![
         AccountMeta::new(*buffer, false),
         AccountMeta::new_readonly(*authority, true),
@@ -22,9 +21,9 @@ pub fn write(
     instruction_data.extend_from_slice(&offset.to_le_bytes());
     instruction_data.extend_from_slice(data);
 
-    Ok(Instruction {
+    Instruction {
         program_id: PROGRAM_ID,
         accounts,
         data: instruction_data,
-    })
+    }
 }

--- a/program/tests/trim.rs
+++ b/program/tests/trim.rs
@@ -48,8 +48,7 @@ fn test_trim_canonical() {
                         data_source: 0,
                     },
                     Some(&[1u8; 10]),
-                )
-                .unwrap(),
+                ),
                 &[
                     Check::success(),
                     // account discriminator
@@ -71,8 +70,7 @@ fn test_trim_canonical() {
                     Some(&program_key),
                     Some(&program_data_key),
                     &destination_key,
-                )
-                .unwrap(),
+                ),
                 &[
                     Check::success(),
                     // account discriminator
@@ -145,8 +143,7 @@ fn test_trim_non_canonical() {
                         data_source: 0,
                     },
                     Some(&[1u8; 10]),
-                )
-                .unwrap(),
+                ),
                 &[
                     Check::success(),
                     // account discriminator
@@ -168,8 +165,7 @@ fn test_trim_non_canonical() {
                     Some(&program_key),
                     Some(&program_data_key),
                     &destination_key,
-                )
-                .unwrap(),
+                ),
                 &[
                     Check::success(),
                     // account discriminator
@@ -216,7 +212,7 @@ fn test_trim_buffer() {
     process_instructions(
         &[
             (
-                &allocate(&buffer_key, &buffer_key, None, None, None).unwrap(),
+                &allocate(&buffer_key, &buffer_key, None, None, None),
                 &[
                     Check::success(),
                     // data lenght
@@ -230,7 +226,7 @@ fn test_trim_buffer() {
                 ],
             ),
             (
-                &trim(&buffer_key, &buffer_key, None, None, &destination_key).unwrap(),
+                &trim(&buffer_key, &buffer_key, None, None, &destination_key),
                 &[
                     Check::success(),
                     // data lenght
@@ -285,8 +281,7 @@ fn fail_trim_non_rent_exempt_account() {
                 None,
                 None,
                 &destination_key,
-            )
-            .unwrap(),
+            ),
             &[
                 Check::err(ProgramError::AccountNotRentExempt),
                 Check::account(&destination_key)
@@ -319,7 +314,7 @@ fn fail_trim_with_wrong_authority() {
     process_instructions(
         &[
             (
-                &allocate(&buffer_key, &buffer_key, None, None, None).unwrap(),
+                &allocate(&buffer_key, &buffer_key, None, None, None),
                 &[Check::success()],
             ),
             (
@@ -329,8 +324,7 @@ fn fail_trim_with_wrong_authority() {
                     None,
                     None,
                     &destination_key,
-                )
-                .unwrap(),
+                ),
                 &[Check::err(ProgramError::IncorrectAuthority)],
             ),
         ],
@@ -353,7 +347,7 @@ fn fail_trim_account_with_empty_discriminator() {
 
     process_instruction(
         (
-            &trim(&account_key, &account_key, None, None, &destination_key).unwrap(),
+            &trim(&account_key, &account_key, None, None, &destination_key),
             &[Check::err(ProgramError::UninitializedAccount)],
         ),
         &[

--- a/program/tests/trim.rs
+++ b/program/tests/trim.rs
@@ -304,3 +304,64 @@ fn fail_trim_non_rent_exempt_account() {
         ],
     );
 }
+
+#[test]
+fn fail_trim_with_wrong_authority() {
+    let buffer_key = Pubkey::new_unique();
+    let wrong_authority_key = Pubkey::new_unique();
+    let buffer_account = create_funded_account(
+        minimum_balance_for(Buffer::LEN + EXCESS_LAMPORTS),
+        system_program::ID,
+    );
+
+    let destination_key = Pubkey::new_unique();
+
+    process_instructions(
+        &[
+            (
+                &allocate(&buffer_key, &buffer_key, None, None, None).unwrap(),
+                &[Check::success()],
+            ),
+            (
+                &trim(
+                    &buffer_key,
+                    &wrong_authority_key,
+                    None,
+                    None,
+                    &destination_key,
+                )
+                .unwrap(),
+                &[Check::err(ProgramError::IncorrectAuthority)],
+            ),
+        ],
+        &[
+            (buffer_key, buffer_account),
+            (PROGRAM_ID, Account::default()),
+            (wrong_authority_key, Account::default()),
+            (destination_key, Account::default()),
+            keyed_account_for_system_program(),
+            (rent::ID, rent_sysvar()),
+        ],
+    );
+}
+
+#[test]
+fn fail_trim_account_with_empty_discriminator() {
+    let account_key = Pubkey::new_unique();
+    let account = create_empty_account(Buffer::LEN, PROGRAM_ID);
+    let destination_key = Pubkey::new_unique();
+
+    process_instruction(
+        (
+            &trim(&account_key, &account_key, None, None, &destination_key).unwrap(),
+            &[Check::err(ProgramError::UninitializedAccount)],
+        ),
+        &[
+            (account_key, account),
+            (PROGRAM_ID, Account::default()),
+            (destination_key, Account::default()),
+            keyed_account_for_system_program(),
+            (rent::ID, rent_sysvar()),
+        ],
+    );
+}

--- a/program/tests/write.rs
+++ b/program/tests/write.rs
@@ -116,6 +116,47 @@ fn test_write_from_buffer() {
 }
 
 #[test]
+fn test_write_with_non_zero_offset_and_overwrite() {
+    let buffer_key = Pubkey::new_unique();
+    let initial_data: [u8; 3] = [9, 8, 7];
+    let updated_data: [u8; 2] = [1, 2];
+    let buffer_account =
+        create_funded_account(minimum_balance_for(Buffer::LEN + 8), system_program::ID);
+
+    process_instructions(
+        &[
+            (
+                &allocate(&buffer_key, &buffer_key, None, None, None).unwrap(),
+                &[Check::success()],
+            ),
+            (
+                &write(&buffer_key, &buffer_key, None, 5, &initial_data).unwrap(),
+                &[
+                    Check::success(),
+                    Check::account(&buffer_key)
+                        .data_slice(Buffer::LEN, &[0, 0, 0, 0, 0, 9, 8, 7])
+                        .build(),
+                ],
+            ),
+            (
+                &write(&buffer_key, &buffer_key, None, 6, &updated_data).unwrap(),
+                &[
+                    Check::success(),
+                    Check::account(&buffer_key)
+                        .data_slice(Buffer::LEN, &[0, 0, 0, 0, 0, 9, 1, 2])
+                        .build(),
+                ],
+            ),
+        ],
+        &[
+            (buffer_key, buffer_account),
+            (PROGRAM_ID, Account::default()),
+            keyed_account_for_system_program(),
+        ],
+    );
+}
+
+#[test]
 fn fail_write_with_wrong_authority() {
     let buffer_key = Pubkey::new_unique();
     let wrong_authority_key = Pubkey::new_unique();
@@ -140,6 +181,36 @@ fn fail_write_with_wrong_authority() {
             (buffer_key, buffer_account),
             (PROGRAM_ID, Account::default()),
             (wrong_authority_key, Account::default()),
+            keyed_account_for_system_program(),
+        ],
+    );
+}
+
+#[test]
+fn fail_write_from_wrong_owner_source_buffer() {
+    // A source buffer owned by a different program should not be
+    // allowed to write to the target buffer.
+    let source_key = Pubkey::new_unique();
+
+    let target_key = Pubkey::new_unique();
+    let target_account =
+        create_funded_account(minimum_balance_for(Buffer::LEN), system_program::ID);
+
+    process_instructions(
+        &[
+            (
+                &allocate(&target_key, &target_key, None, None, None).unwrap(),
+                &[Check::success()],
+            ),
+            (
+                &write(&target_key, &target_key, Some(&source_key), 0, &[]).unwrap(),
+                &[Check::err(ProgramError::InvalidAccountOwner)],
+            ),
+        ],
+        &[
+            (source_key, Account::default()),
+            (target_key, target_account),
+            (PROGRAM_ID, Account::default()),
             keyed_account_for_system_program(),
         ],
     );

--- a/program/tests/write.rs
+++ b/program/tests/write.rs
@@ -1,0 +1,221 @@
+mod setup;
+pub use setup::*;
+
+use mollusk_svm::{program::keyed_account_for_system_program, result::Check};
+use solana_account::Account;
+use solana_program_error::ProgramError;
+use solana_pubkey::Pubkey;
+use solana_sdk_ids::system_program;
+use spl_program_metadata::state::buffer::Buffer;
+
+#[test]
+fn test_write_instruction_data() {
+    let buffer_key = Pubkey::new_unique();
+    let data = [1u8; 10];
+    let buffer_account = create_funded_account(
+        minimum_balance_for(Buffer::LEN + data.len()),
+        system_program::ID,
+    );
+
+    process_instructions(
+        &[
+            (
+                &allocate(&buffer_key, &buffer_key, None, None, None).unwrap(),
+                &[
+                    Check::success(),
+                    // account discriminator
+                    Check::account(&buffer_key).data_slice(0, &[1]).build(),
+                    // data length
+                    Check::account(&buffer_key).space(Buffer::LEN).build(),
+                ],
+            ),
+            (
+                &write(&buffer_key, &buffer_key, None, 0, &data).unwrap(),
+                &[
+                    Check::success(),
+                    // data length
+                    Check::account(&buffer_key)
+                        .space(Buffer::LEN + data.len())
+                        .build(),
+                    // buffer data
+                    Check::account(&buffer_key)
+                        .data_slice(Buffer::LEN, &data)
+                        .build(),
+                ],
+            ),
+        ],
+        &[
+            (buffer_key, buffer_account),
+            (PROGRAM_ID, Account::default()),
+            keyed_account_for_system_program(),
+        ],
+    );
+}
+
+#[test]
+fn test_write_from_buffer() {
+    let source_key = Pubkey::new_unique();
+    let target_key = Pubkey::new_unique();
+    let data = [2u8; 12];
+
+    let source_account = create_funded_account(
+        minimum_balance_for(Buffer::LEN + data.len()),
+        system_program::ID,
+    );
+    let target_account = create_funded_account(
+        minimum_balance_for(Buffer::LEN + data.len()),
+        system_program::ID,
+    );
+
+    process_instructions(
+        &[
+            (
+                &allocate(&source_key, &source_key, None, None, None).unwrap(),
+                &[
+                    Check::success(),
+                    // account discriminator
+                    Check::account(&source_key).data_slice(0, &[1]).build(),
+                ],
+            ),
+            (
+                &write(&source_key, &source_key, None, 0, &data).unwrap(),
+                &[
+                    Check::success(),
+                    // source buffer data
+                    Check::account(&source_key)
+                        .data_slice(Buffer::LEN, &data)
+                        .build(),
+                ],
+            ),
+            (
+                &allocate(&target_key, &target_key, None, None, None).unwrap(),
+                &[
+                    Check::success(),
+                    // account discriminator
+                    Check::account(&target_key).data_slice(0, &[1]).build(),
+                ],
+            ),
+            (
+                &write(&target_key, &target_key, Some(&source_key), 0, &[]).unwrap(),
+                &[
+                    Check::success(),
+                    // target buffer data
+                    Check::account(&target_key)
+                        .data_slice(Buffer::LEN, &data)
+                        .build(),
+                ],
+            ),
+        ],
+        &[
+            (source_key, source_account),
+            (target_key, target_account),
+            (PROGRAM_ID, Account::default()),
+            keyed_account_for_system_program(),
+        ],
+    );
+}
+
+#[test]
+fn fail_write_with_wrong_authority() {
+    let buffer_key = Pubkey::new_unique();
+    let wrong_authority_key = Pubkey::new_unique();
+    let data = [9u8; 4];
+    let buffer_account = create_funded_account(
+        minimum_balance_for(Buffer::LEN + data.len()),
+        system_program::ID,
+    );
+
+    process_instructions(
+        &[
+            (
+                &allocate(&buffer_key, &buffer_key, None, None, None).unwrap(),
+                &[Check::success()],
+            ),
+            (
+                &write(&buffer_key, &wrong_authority_key, None, 0, &data).unwrap(),
+                &[Check::err(ProgramError::IncorrectAuthority)],
+            ),
+        ],
+        &[
+            (buffer_key, buffer_account),
+            (PROGRAM_ID, Account::default()),
+            (wrong_authority_key, Account::default()),
+            keyed_account_for_system_program(),
+        ],
+    );
+}
+
+#[test]
+fn fail_write_empty_data_without_source_buffer() {
+    let buffer_key = Pubkey::new_unique();
+    let buffer_account =
+        create_funded_account(minimum_balance_for(Buffer::LEN), system_program::ID);
+
+    process_instructions(
+        &[
+            (
+                &allocate(&buffer_key, &buffer_key, None, None, None).unwrap(),
+                &[Check::success()],
+            ),
+            (
+                &write(&buffer_key, &buffer_key, None, 0, &[]).unwrap(),
+                &[Check::err(ProgramError::InvalidInstructionData)],
+            ),
+        ],
+        &[
+            (buffer_key, buffer_account),
+            (PROGRAM_ID, Account::default()),
+            keyed_account_for_system_program(),
+        ],
+    );
+}
+
+#[test]
+fn fail_write_from_same_buffer() {
+    let buffer_key = Pubkey::new_unique();
+    let buffer_account =
+        create_funded_account(minimum_balance_for(Buffer::LEN), system_program::ID);
+
+    process_instructions(
+        &[
+            (
+                &allocate(&buffer_key, &buffer_key, None, None, None).unwrap(),
+                &[Check::success()],
+            ),
+            (
+                &write(&buffer_key, &buffer_key, Some(&buffer_key), 0, &[]).unwrap(),
+                &[Check::err(ProgramError::InvalidAccountData)],
+            ),
+        ],
+        &[
+            (buffer_key, buffer_account),
+            (PROGRAM_ID, Account::default()),
+            keyed_account_for_system_program(),
+        ],
+    );
+}
+
+#[test]
+fn fail_write_without_rent_for_growth() {
+    let buffer_key = Pubkey::new_unique();
+    let buffer_account =
+        create_funded_account(minimum_balance_for(Buffer::LEN), system_program::ID);
+
+    process_instructions(
+        &[
+            (
+                &allocate(&buffer_key, &buffer_key, None, None, None).unwrap(),
+                &[Check::success()],
+            ),
+            (
+                &write(&buffer_key, &buffer_key, None, 0, &[1]).unwrap(),
+                &[Check::err(ProgramError::AccountNotRentExempt)],
+            ),
+        ],
+        &[
+            (buffer_key, buffer_account),
+            (PROGRAM_ID, Account::default()),
+            keyed_account_for_system_program(),
+        ],
+    );
+}

--- a/program/tests/write.rs
+++ b/program/tests/write.rs
@@ -20,7 +20,7 @@ fn test_write_instruction_data() {
     process_instructions(
         &[
             (
-                &allocate(&buffer_key, &buffer_key, None, None, None).unwrap(),
+                &allocate(&buffer_key, &buffer_key, None, None, None),
                 &[
                     Check::success(),
                     // account discriminator
@@ -30,7 +30,7 @@ fn test_write_instruction_data() {
                 ],
             ),
             (
-                &write(&buffer_key, &buffer_key, None, 0, &data).unwrap(),
+                &write(&buffer_key, &buffer_key, None, 0, &data),
                 &[
                     Check::success(),
                     // data length
@@ -70,7 +70,7 @@ fn test_write_from_buffer() {
     process_instructions(
         &[
             (
-                &allocate(&source_key, &source_key, None, None, None).unwrap(),
+                &allocate(&source_key, &source_key, None, None, None),
                 &[
                     Check::success(),
                     // account discriminator
@@ -78,7 +78,7 @@ fn test_write_from_buffer() {
                 ],
             ),
             (
-                &write(&source_key, &source_key, None, 0, &data).unwrap(),
+                &write(&source_key, &source_key, None, 0, &data),
                 &[
                     Check::success(),
                     // source buffer data
@@ -88,7 +88,7 @@ fn test_write_from_buffer() {
                 ],
             ),
             (
-                &allocate(&target_key, &target_key, None, None, None).unwrap(),
+                &allocate(&target_key, &target_key, None, None, None),
                 &[
                     Check::success(),
                     // account discriminator
@@ -96,7 +96,7 @@ fn test_write_from_buffer() {
                 ],
             ),
             (
-                &write(&target_key, &target_key, Some(&source_key), 0, &[]).unwrap(),
+                &write(&target_key, &target_key, Some(&source_key), 0, &[]),
                 &[
                     Check::success(),
                     // target buffer data
@@ -126,11 +126,11 @@ fn test_write_with_non_zero_offset_and_overwrite() {
     process_instructions(
         &[
             (
-                &allocate(&buffer_key, &buffer_key, None, None, None).unwrap(),
+                &allocate(&buffer_key, &buffer_key, None, None, None),
                 &[Check::success()],
             ),
             (
-                &write(&buffer_key, &buffer_key, None, 5, &initial_data).unwrap(),
+                &write(&buffer_key, &buffer_key, None, 5, &initial_data),
                 &[
                     Check::success(),
                     Check::account(&buffer_key)
@@ -139,7 +139,7 @@ fn test_write_with_non_zero_offset_and_overwrite() {
                 ],
             ),
             (
-                &write(&buffer_key, &buffer_key, None, 6, &updated_data).unwrap(),
+                &write(&buffer_key, &buffer_key, None, 6, &updated_data),
                 &[
                     Check::success(),
                     Check::account(&buffer_key)
@@ -169,11 +169,11 @@ fn fail_write_with_wrong_authority() {
     process_instructions(
         &[
             (
-                &allocate(&buffer_key, &buffer_key, None, None, None).unwrap(),
+                &allocate(&buffer_key, &buffer_key, None, None, None),
                 &[Check::success()],
             ),
             (
-                &write(&buffer_key, &wrong_authority_key, None, 0, &data).unwrap(),
+                &write(&buffer_key, &wrong_authority_key, None, 0, &data),
                 &[Check::err(ProgramError::IncorrectAuthority)],
             ),
         ],
@@ -199,11 +199,11 @@ fn fail_write_from_wrong_owner_source_buffer() {
     process_instructions(
         &[
             (
-                &allocate(&target_key, &target_key, None, None, None).unwrap(),
+                &allocate(&target_key, &target_key, None, None, None),
                 &[Check::success()],
             ),
             (
-                &write(&target_key, &target_key, Some(&source_key), 0, &[]).unwrap(),
+                &write(&target_key, &target_key, Some(&source_key), 0, &[]),
                 &[Check::err(ProgramError::InvalidAccountOwner)],
             ),
         ],
@@ -225,11 +225,11 @@ fn fail_write_empty_data_without_source_buffer() {
     process_instructions(
         &[
             (
-                &allocate(&buffer_key, &buffer_key, None, None, None).unwrap(),
+                &allocate(&buffer_key, &buffer_key, None, None, None),
                 &[Check::success()],
             ),
             (
-                &write(&buffer_key, &buffer_key, None, 0, &[]).unwrap(),
+                &write(&buffer_key, &buffer_key, None, 0, &[]),
                 &[Check::err(ProgramError::InvalidInstructionData)],
             ),
         ],
@@ -250,11 +250,11 @@ fn fail_write_from_same_buffer() {
     process_instructions(
         &[
             (
-                &allocate(&buffer_key, &buffer_key, None, None, None).unwrap(),
+                &allocate(&buffer_key, &buffer_key, None, None, None),
                 &[Check::success()],
             ),
             (
-                &write(&buffer_key, &buffer_key, Some(&buffer_key), 0, &[]).unwrap(),
+                &write(&buffer_key, &buffer_key, Some(&buffer_key), 0, &[]),
                 &[Check::err(ProgramError::InvalidAccountData)],
             ),
         ],
@@ -275,11 +275,11 @@ fn fail_write_without_rent_for_growth() {
     process_instructions(
         &[
             (
-                &allocate(&buffer_key, &buffer_key, None, None, None).unwrap(),
+                &allocate(&buffer_key, &buffer_key, None, None, None),
                 &[Check::success()],
             ),
             (
-                &write(&buffer_key, &buffer_key, None, 0, &[1]).unwrap(),
+                &write(&buffer_key, &buffer_key, None, 0, &[1]),
                 &[Check::err(ProgramError::AccountNotRentExempt)],
             ),
         ],


### PR DESCRIPTION
### Problem

Currently the program tests (mollusk) do not test all instructions.

### Solution

Add tests for all instructions.

While adding the tests, two small tweaks were done:
1. Remove the redundant "optional" label from comments.
2. Use a more precise error type when validating the `SetData` instruction data.