### PR TITLE
Show workflow inputs in publish run summaries

### DIFF
--- a/.github/workflows/publish-js.yml
+++ b/.github/workflows/publish-js.yml
@@ -46,7 +46,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Summarise workflow inputs
-        uses: lorisleiva/workflow-inputs-action@v1
+        uses: solana-program/actions/workflow-inputs@v1
 
       - name: Compute variables
         id: compute

--- a/.github/workflows/publish-js.yml
+++ b/.github/workflows/publish-js.yml
@@ -45,6 +45,9 @@ jobs:
       - name: Git Checkout
         uses: actions/checkout@v4
 
+      - name: Summarise workflow inputs
+        uses: lorisleiva/workflow-inputs-action@v1
+
       - name: Compute variables
         id: compute
         shell: bash

--- a/.github/workflows/publish-rust.yml
+++ b/.github/workflows/publish-rust.yml
@@ -53,7 +53,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Summarise workflow inputs
-        uses: lorisleiva/workflow-inputs-action@v1
+        uses: solana-program/actions/workflow-inputs@v1
 
       - name: Compute variables
         id: compute

--- a/.github/workflows/publish-rust.yml
+++ b/.github/workflows/publish-rust.yml
@@ -52,6 +52,9 @@ jobs:
       - name: Git Checkout
         uses: actions/checkout@v4
 
+      - name: Summarise workflow inputs
+        uses: lorisleiva/workflow-inputs-action@v1
+
       - name: Compute variables
         id: compute
         shell: bash


### PR DESCRIPTION
This PR adds [`lorisleiva/workflow-inputs-action@v1`](https://github.com/lorisleiva/workflow-inputs-action) to both publish workflows so the inputs used to dispatch a run are rendered as a table in the job summary. Makes it easy to see what was requested when reviewing a publish run later.