### PR TITLE
program: Add missing repr attributes

### DIFF
--- a/program/src/processor/initialize.rs
+++ b/program/src/processor/initialize.rs
@@ -206,6 +206,7 @@ pub fn initialize(accounts: &mut [AccountView], instruction_data: &[u8]) -> Prog
 }
 
 /// The instruction data for the `Initialize` instruction.
+#[repr(C)]
 struct Initialize {
     pub seed: [u8; 16],
     pub encoding: u8,

--- a/program/src/processor/set_data.rs
+++ b/program/src/processor/set_data.rs
@@ -154,6 +154,7 @@ fn update_header<'a>(
 }
 
 /// The instruction data for the `SetData` instruction.
+#[repr(C)]
 struct SetData {
     pub encoding: u8,
     pub compression: u8,

--- a/program/src/processor/write.rs
+++ b/program/src/processor/write.rs
@@ -122,6 +122,7 @@ pub fn write(accounts: &mut [AccountView], instruction_data: &[u8]) -> ProgramRe
 }
 
 /// Instruction data expected by the `Write` instruction.
+#[repr(C)]
 struct Write<'a> {
     /// Offset to write to.
     offset: &'a [u8; 4],

--- a/program/src/state/data.rs
+++ b/program/src/state/data.rs
@@ -51,6 +51,7 @@ pub struct UrlData<'a>(pub &'a str);
 ///
 /// External data contains a reference (address) to an external account
 /// and an offset and an optional length to specify the data range.
+#[repr(C)]
 pub struct ExternalData {
     /// Address of the external account.
     pub address: Address,

--- a/program/src/state/mod.rs
+++ b/program/src/state/mod.rs
@@ -197,8 +197,9 @@ impl Zeroable for u32 {
     const ZERO: Self = 0;
 }
 
-/// Trait for types that are considered `None` when their value
+/// Wrapper for types that are considered `None` when their value
 /// is equal to `Zeroable::ZERO`.
+#[repr(transparent)]
 #[derive(Clone, Debug)]
 pub struct ZeroableOption<T: Zeroable>(T);
 


### PR DESCRIPTION
### Problem

There are a few structs used in the program with missing `repr` attribute.

### Solution

Add a `repr` attribute to all structs.