### PR TITLE
program: Remove duplicated authority signer check on `close`

### DIFF
--- a/program/src/processor/close.rs
+++ b/program/src/processor/close.rs
@@ -18,13 +18,6 @@ pub fn close(accounts: &mut [AccountView]) -> ProgramResult {
     // Note that program owned and writable checks are done implicitly by writing
     // to the account.
 
-    // authority
-    // - must be a signer
-
-    if !authority.is_signer() {
-        return Err(ProgramError::MissingRequiredSignature);
-    }
-
     // account
     // - must have data
     // - authority must match
@@ -35,6 +28,9 @@ pub fn close(accounts: &mut [AccountView]) -> ProgramResult {
         // SAFETY: Single borrow of the `account` data.
         unsafe { account.borrow_unchecked() }
     };
+
+    // authority
+    // - must be a signer (checked in `validate_authority`)
 
     match AccountDiscriminator::try_from(account_data[0])? {
         AccountDiscriminator::Buffer => {


### PR DESCRIPTION
### Problem

The authority signer check is part of the `validate_authority` but it is also being checked separately on `close`. This is unnecessary.

### Solution

Remove the duplicated signer check.