### PR TITLE
program: Add const asserts

### DIFF
--- a/program/src/processor/initialize.rs
+++ b/program/src/processor/initialize.rs
@@ -1,3 +1,5 @@
+use core::mem::{align_of, size_of};
+
 use pinocchio::{
     cpi::{Seed, Signer},
     error::ProgramError,
@@ -215,8 +217,13 @@ struct Initialize {
     pub data_source: u8,
 }
 
+// Enforces 1-byte alignment for the struct.
+const _: () = {
+    assert!(align_of::<Initialize>() == 1);
+};
+
 impl Initialize {
-    const LEN: usize = core::mem::size_of::<Self>();
+    const LEN: usize = size_of::<Self>();
 
     /// # Safety
     ///

--- a/program/src/processor/set_data.rs
+++ b/program/src/processor/set_data.rs
@@ -1,3 +1,5 @@
+use core::mem::{align_of, size_of};
+
 use pinocchio::{account::AccountView, error::ProgramError, ProgramResult, Resize};
 
 use crate::state::{
@@ -164,8 +166,13 @@ struct SetData {
     // - `&[u8]`: remaining data
 }
 
+// Enforces 1-byte alignment for the struct.
+const _: () = {
+    assert!(align_of::<SetData>() == 1);
+};
+
 impl SetData {
-    const LEN: usize = core::mem::size_of::<Self>();
+    const LEN: usize = size_of::<Self>();
 
     /// # Safety
     ///

--- a/program/src/processor/write.rs
+++ b/program/src/processor/write.rs
@@ -122,7 +122,6 @@ pub fn write(accounts: &mut [AccountView], instruction_data: &[u8]) -> ProgramRe
 }
 
 /// Instruction data expected by the `Write` instruction.
-#[repr(C)]
 struct Write<'a> {
     /// Offset to write to.
     offset: &'a [u8; 4],

--- a/program/src/state/buffer.rs
+++ b/program/src/state/buffer.rs
@@ -1,3 +1,5 @@
+use core::mem::align_of;
+
 use pinocchio::{
     account::{AccountView, Ref},
     error::ProgramError,
@@ -40,6 +42,11 @@ pub struct Buffer {
     /// the metadata [`Header`](`super::Header`).
     _padding: [u8; 14],
 }
+
+// Enforces 1-byte alignment for the struct.
+const _: () = {
+    assert!(align_of::<Buffer>() == 1);
+};
 
 impl Buffer {
     /// The minimum size of a `Buffer` (`96` bytes).

--- a/program/src/state/data.rs
+++ b/program/src/state/data.rs
@@ -1,3 +1,5 @@
+use core::{mem::align_of, str::from_utf8};
+
 use pinocchio::{error::ProgramError, Address};
 
 use super::{DataSource, ZeroableOption};
@@ -23,7 +25,7 @@ impl<'a> Data<'a> {
         Ok(match data_source {
             DataSource::Direct => Data::Direct(DirectData(bytes)),
             DataSource::Url => Data::Url(UrlData(
-                core::str::from_utf8(bytes).map_err(|_| ProgramError::InvalidArgument)?,
+                from_utf8(bytes).map_err(|_| ProgramError::InvalidArgument)?,
             )),
             DataSource::External => {
                 if bytes.len() < ExternalData::LEN {
@@ -66,6 +68,11 @@ pub struct ExternalData {
     /// Default to 0, which means the whole account.
     pub length: ZeroableOption<u32>,
 }
+
+// Enforces 4-byte alignment for the `ExternalData` struct.
+const _: () = {
+    assert!(align_of::<ExternalData>() == 4);
+};
 
 impl ExternalData {
     pub const LEN: usize = core::mem::size_of::<ExternalData>();

--- a/program/src/state/data.rs
+++ b/program/src/state/data.rs
@@ -31,6 +31,9 @@ impl<'a> Data<'a> {
                 if bytes.len() < ExternalData::LEN {
                     return Err(ProgramError::InvalidArgument);
                 }
+                if !(bytes.as_ptr() as usize).is_multiple_of(align_of::<ExternalData>()) {
+                    return Err(ProgramError::InvalidArgument);
+                }
                 // SAFETY: `bytes` was validated to have the expected length
                 // to hold a `Data::External` reference.
                 Data::External(unsafe { &*(bytes.as_ptr() as *const ExternalData) })

--- a/program/src/state/header.rs
+++ b/program/src/state/header.rs
@@ -1,3 +1,5 @@
+use core::mem::align_of;
+
 use pinocchio::{
     account::{AccountView, Ref},
     error::ProgramError,
@@ -55,6 +57,11 @@ pub struct Header {
     /// This allows the data section to start at a 8-byte boundary.
     _padding: [u8; 5],
 }
+
+// Enforces 1-byte alignment for the struct.
+const _: () = {
+    assert!(align_of::<Header>() == 1);
+};
 
 impl Header {
     /// Length of the header (96 bytes).

--- a/program/src/state/mod.rs
+++ b/program/src/state/mod.rs
@@ -2,12 +2,26 @@ pub mod buffer;
 pub mod data;
 pub mod header;
 
+use core::mem::size_of;
+
 use pinocchio::{address::ADDRESS_BYTES, error::ProgramError, Address, ProgramResult};
 
-use data::{Data, ExternalData};
-use header::Header;
+use crate::{
+    error::ProgramMetadataError,
+    state::{
+        buffer::Buffer,
+        data::{Data, ExternalData},
+        header::Header,
+    },
+};
 
-use crate::error::ProgramMetadataError;
+// Make sure both `Header` and `Buffer` structs have the same size.
+const _: () = {
+    assert!(
+        size_of::<Header>() == size_of::<Buffer>(),
+        "Header and Buffer should be the same size"
+    );
+};
 
 /// The length of the seed used to derive the metadata account address.
 pub const SEED_LEN: usize = 16;


### PR DESCRIPTION
### Problem

Many of the `struct`s of the program are interpreted directly from bytes assuming 1-byte alignment. In some cases, structs have constraints that their size must match. While these are correct in the implementation, there are no checks to ensure they remain valid in case of future updates.

### Solution

Add `const` asserts on structs.