### PR TITLE
program: Add note about state types

### DIFF
--- a/program/src/state/buffer.rs
+++ b/program/src/state/buffer.rs
@@ -9,6 +9,10 @@ use super::{Account, AccountDiscriminator, ZeroableOption, SEED_LEN};
 /// Buffer account header.
 ///
 /// A buffer holds a variable amount of data after its header information.
+//
+// Note: `Buffer` may be loaded directly from account data after only a
+// length check (no owner check). All fields must be valid for any bit
+// pattern.
 #[repr(C)]
 pub struct Buffer {
     /// Account discriminator.

--- a/program/src/state/data.rs
+++ b/program/src/state/data.rs
@@ -3,10 +3,6 @@ use pinocchio::{error::ProgramError, Address};
 use super::{DataSource, ZeroableOption};
 
 /// Metadata account data.
-//
-// Note: `Data` may be loaded directly from account data after only a
-// length check (no owner check). All fields must be valid for any bit
-// pattern.
 pub enum Data<'a> {
     /// Represents the case where the metadata is stored on the account.
     Direct(DirectData<'a>),
@@ -55,6 +51,10 @@ pub struct UrlData<'a>(pub &'a str);
 ///
 /// External data contains a reference (address) to an external account
 /// and an offset and an optional length to specify the data range.
+//
+// Note: `ExternalData` may be loaded directly from account data after
+// only a length check (no owner check). All fields must be valid for any
+// bit pattern.
 #[repr(C)]
 pub struct ExternalData {
     /// Address of the external account.

--- a/program/src/state/data.rs
+++ b/program/src/state/data.rs
@@ -3,6 +3,10 @@ use pinocchio::{error::ProgramError, Address};
 use super::{DataSource, ZeroableOption};
 
 /// Metadata account data.
+//
+// Note: `Data` may be loaded directly from account data after only a
+// length check (no owner check). All fields must be valid for any bit
+// pattern.
 pub enum Data<'a> {
     /// Represents the case where the metadata is stored on the account.
     Direct(DirectData<'a>),

--- a/program/src/state/header.rs
+++ b/program/src/state/header.rs
@@ -10,6 +10,10 @@ use super::{
 };
 
 /// Metadata account header.
+//
+// Note: `Header` may be loaded directly from account data after only a
+// length check (no owner check). All fields must be valid for any bit
+// pattern.
 #[repr(C)]
 pub struct Header {
     /// Account discriminator.


### PR DESCRIPTION
### Problem

Account types are loaded directly from account data, so only pod-like types must be used.

### Solution

Add a note to the implementation of account types.