### PR TITLE
program: Use macro for conditional logging

### DIFF
--- a/program/src/entrypoint.rs
+++ b/program/src/entrypoint.rs
@@ -2,8 +2,6 @@ use pinocchio::{
     default_panic_handler, error::ProgramError, no_allocator, program_entrypoint, AccountView,
     Address, ProgramResult,
 };
-#[cfg(feature = "logging")]
-use solana_program_log::log;
 
 use crate::{
     instruction::ProgramMetadataInstruction,
@@ -20,6 +18,14 @@ default_panic_handler!();
 // No allocator is used.
 no_allocator!();
 
+/// Logs a message if the "logging" feature is enabled.
+macro_rules! cfg_log {
+    ($msg:literal) => {
+        #[cfg(feature = "logging")]
+        solana_program_log::log($msg);
+    };
+}
+
 fn process_instruction(
     _program_id: &Address,
     accounts: &mut [AccountView],
@@ -32,65 +38,47 @@ fn process_instruction(
     match ProgramMetadataInstruction::try_from(*instruction)? {
         // 0 - Write
         ProgramMetadataInstruction::Write => {
-            #[cfg(feature = "logging")]
-            log("Instruction: Write");
-
+            cfg_log!("Instruction: Write");
             write(accounts, data)
         }
         // 1 - Initialize
         ProgramMetadataInstruction::Initialize => {
-            #[cfg(feature = "logging")]
-            log("Instruction: Initialize");
-
+            cfg_log!("Instruction: Initialize");
             initialize(accounts, data)
         }
         // 2 - SetAuthority
         ProgramMetadataInstruction::SetAuthority => {
-            #[cfg(feature = "logging")]
-            log("Instruction: SetAuthority");
-
+            cfg_log!("Instruction: SetAuthority");
             set_authority(accounts, data)
         }
         // 3 - SetData
         ProgramMetadataInstruction::SetData => {
-            #[cfg(feature = "logging")]
-            log("Instruction: SetData");
-
+            cfg_log!("Instruction: SetData");
             set_data(accounts, data)
         }
         // 4 - SetImmutable
         ProgramMetadataInstruction::SetImmutable => {
-            #[cfg(feature = "logging")]
-            log("Instruction: SetImmutable");
-
+            cfg_log!("Instruction: SetImmutable");
             set_immutable(accounts)
         }
         // 5 - Trim
         ProgramMetadataInstruction::Trim => {
-            #[cfg(feature = "logging")]
-            log("Instruction: Trim");
-
+            cfg_log!("Instruction: Trim");
             trim(accounts)
         }
         // 6 - Close
         ProgramMetadataInstruction::Close => {
-            #[cfg(feature = "logging")]
-            log("Instruction: Close");
-
+            cfg_log!("Instruction: Close");
             close(accounts)
         }
         // 7 - Allocate
         ProgramMetadataInstruction::Allocate => {
-            #[cfg(feature = "logging")]
-            log("Instruction: Allocate");
-
+            cfg_log!("Instruction: Allocate");
             allocate(accounts, data)
         }
         // 8 - Extend
         ProgramMetadataInstruction::Extend => {
-            #[cfg(feature = "logging")]
-            log("Instruction: Extend");
-
+            cfg_log!("Instruction: Extend");
             extend(accounts, data)
         }
     }


### PR DESCRIPTION
### Problem

The program implementation uses conditional logging for the instruction name, but currently there is a bit of code repetition that can be avoided.

### Solution

Create a simple `macro_rules` to encapsulate the cfg gating of the log message.