### PR TITLE
program: Add comment for program discriminator

### DIFF
--- a/program/src/processor/mod.rs
+++ b/program/src/processor/mod.rs
@@ -64,8 +64,10 @@ fn is_program_authority(
     let expected_program_data = {
         let data = unsafe { program.borrow_unchecked() };
         match (data.first(), program.executable()) {
-            (Some(2 /* program discriminator */), true) => {
-                let offset: usize = 4 /* discriminator */;
+            // The discriminator is 4 bytes, but we only need to check the first byte
+            // since there are fewer than 256 account types.
+            (Some(2), true) => {
+                let offset: usize = 4;
                 Address::try_from(&data[offset..offset + ADDRESS_BYTES])
                     .map_err(|_| ProgramError::InvalidAccountData)?
             }


### PR DESCRIPTION
### Problem

When checking the discriminator on a program account, only the first byte is checked since there are fewer than `256` account types. Currently, the rationale is not explained.

### Solution

Add a comment to clarify the use of only 1 byte.