### PR TITLE
program: Update instruction comments

### DIFF
--- a/program/src/instruction.rs
+++ b/program/src/instruction.rs
@@ -227,6 +227,8 @@ pub enum ProgramMetadataInstruction {
     /// The account is expected to be pre-funded with the required lamports
     /// for the new size.
     ///
+    /// Note: Immutable metadata accounts cannot be extended.
+    ///
     /// There are 2 optional accounts:
     ///   - `program`: required to validate whether the authority is the program upgrade
     ///     authority.

--- a/program/src/instruction.rs
+++ b/program/src/instruction.rs
@@ -148,6 +148,8 @@ pub enum ProgramMetadataInstruction {
     /// minimum size required to be rent exempt, returning any extra
     /// lamports to the `destination` account.
     ///
+    /// Note: Immutable metadata accounts cannot be trimmed.
+    ///
     /// There are 2 optional accounts:
     ///   - `program`: required to validate whether the authority is the program upgrade
     ///     authority.
@@ -160,8 +162,8 @@ pub enum ProgramMetadataInstruction {
     ///  1. `[s]` Authority account.
     ///  2. `[o]` Program account.
     ///  3. `[o]` Program data account.
-    ///  5. `[w]` Destination account.
-    ///  6. `[]` Rent sysvar account.
+    ///  4. `[w]` Destination account.
+    ///  5. `[ ]` Rent sysvar account.
     Trim,
 
     /// Closes a program-owned buffer or metadata account.
@@ -184,7 +186,7 @@ pub enum ProgramMetadataInstruction {
     ///  1. `[s]` Metadata authority or buffer account.
     ///  2. `[o]` Program account.
     ///  3. `[o]` Program data account.
-    ///  5. `[w]` Destination account.
+    ///  4. `[w]` Destination account.
     Close,
 
     /// Allocates a buffer account.

--- a/program/src/processor/extend.rs
+++ b/program/src/processor/extend.rs
@@ -36,7 +36,7 @@ pub fn extend(accounts: &mut [AccountView], instruction_data: &[u8]) -> ProgramR
 
     // account
     // - authority must be a signer (validated by `validate_authority`)
-    // - must be a buffer or metadata account
+    // - must be a buffer or mutable metadata account
     // - must have a valid authority
     // - must be rent exempt (pre-funded account) since we are reallocating the buffer
     //   account

--- a/program/src/processor/trim.rs
+++ b/program/src/processor/trim.rs
@@ -23,7 +23,7 @@ pub fn trim(accounts: &mut [AccountView]) -> ProgramResult {
 
     // account
     // - authority must be a signer (checked by `validate_authority`)
-    // - must be a buffer or metadata account
+    // - must be a buffer or mutable metadata account
     // - must have a valid authority
 
     if account.is_data_empty() {


### PR DESCRIPTION
### Problem

There are a couple of issues in the comments:
* Incorrect account indices in `Trim` and `Close`.
* `Extend` and `Trim` do not specify that metadata accounts need to be mutable.

### Solution

Update the comments fixing account indices and explicitly mentioning that immutable metadata accounts cannot be extended nor trimmed.