### PR TITLE
program: Relax minimum rent check

### DIFF
--- a/program/src/processor/allocate.rs
+++ b/program/src/processor/allocate.rs
@@ -1,7 +1,6 @@
 use pinocchio::{
     cpi::{Seed, Signer},
     error::ProgramError,
-    sysvars::{rent::Rent, Sysvar},
     AccountView, ProgramResult,
 };
 use pinocchio_system::instructions::{Allocate, Assign};
@@ -139,10 +138,9 @@ pub fn allocate(accounts: &mut [AccountView], instruction_data: &[u8]) -> Progra
         _ => return Err(ProgramError::InvalidAccountData),
     }
 
-    // `buffer` length is within the permitted limit.
-    let minimum_balance = Rent::get()?.minimum_balance_unchecked(buffer.data_len());
-
-    if buffer.lamports() < minimum_balance {
+    // The buffer account must have non-zero lamports. The runtime will then
+    // ensure that the account is rent exempt.
+    if buffer.lamports() == 0 {
         return Err(ProgramError::AccountNotRentExempt);
     }
 

--- a/program/src/processor/allocate.rs
+++ b/program/src/processor/allocate.rs
@@ -39,7 +39,8 @@ pub fn allocate(accounts: &mut [AccountView], instruction_data: &[u8]) -> Progra
     // buffer
     // - if pda, must have the correct derivation + seed; otherwise must be
     //   a signer (match the authority)
-    // - must be rent exempt (pre-funded account)
+    // - must have lamports (pre-funded account); the runtime will ensure
+    //   that the account is rent exempt
 
     let (is_pda, bump, canonical) = if buffer.address() == authority.address() {
         // A keypair buffer does not require a `seed` value.

--- a/program/src/processor/extend.rs
+++ b/program/src/processor/extend.rs
@@ -34,7 +34,8 @@ pub fn extend(accounts: &mut [AccountView], instruction_data: &[u8]) -> ProgramR
     // - must be a buffer or metadata account
     // - must have a valid authority
     // - must be rent exempt (pre-funded account) since we are reallocating the
-    //   account (checked by the runtime)
+    //   account (checked by the runtime); both `allocate` and `initialize` ensure
+    //   that the account has at least some lamports
 
     if account.is_data_empty() {
         return Err(ProgramError::InvalidAccountData);

--- a/program/src/processor/extend.rs
+++ b/program/src/processor/extend.rs
@@ -1,10 +1,5 @@
 use core::mem::size_of;
-use pinocchio::{
-    account::AccountView,
-    error::ProgramError,
-    sysvars::{rent::Rent, Sysvar},
-    ProgramResult, Resize,
-};
+use pinocchio::{account::AccountView, error::ProgramError, ProgramResult, Resize};
 
 use crate::state::{buffer::Buffer, AccountDiscriminator};
 
@@ -39,7 +34,7 @@ pub fn extend(accounts: &mut [AccountView], instruction_data: &[u8]) -> ProgramR
     // - must be a buffer or metadata account
     // - must have a valid authority
     // - must be rent exempt (pre-funded account) since we are reallocating the buffer
-    //   account
+    //   account (checked by the runtime)
 
     if account.is_data_empty() {
         return Err(ProgramError::InvalidAccountData);
@@ -62,18 +57,11 @@ pub fn extend(accounts: &mut [AccountView], instruction_data: &[u8]) -> ProgramR
         }
     }
 
+    // Reallocates the account size.
+
     // The length of the data is never more than `10_000_000`; adding a `u16`
     // will never overflow the `usize` limit.
     let length = account.data_len() + extend_length as usize;
-
-    let minimum_balance = Rent::get()?.try_minimum_balance(length)?;
-
-    if account.lamports() < minimum_balance {
-        return Err(ProgramError::AccountNotRentExempt);
-    }
-
-    // Reallocates the account size.
-
     // SAFETY: `account` is not borrowed at this point.
     unsafe { account.resize_unchecked(length) }
 }

--- a/program/src/processor/extend.rs
+++ b/program/src/processor/extend.rs
@@ -33,7 +33,7 @@ pub fn extend(accounts: &mut [AccountView], instruction_data: &[u8]) -> ProgramR
     // - authority must be a signer (validated by `validate_authority`)
     // - must be a buffer or metadata account
     // - must have a valid authority
-    // - must be rent exempt (pre-funded account) since we are reallocating the buffer
+    // - must be rent exempt (pre-funded account) since we are reallocating the
     //   account (checked by the runtime)
 
     if account.is_data_empty() {

--- a/program/src/processor/initialize.rs
+++ b/program/src/processor/initialize.rs
@@ -4,7 +4,6 @@ use pinocchio::{
     cpi::{Seed, Signer},
     error::ProgramError,
     instruction::seeds,
-    sysvars::{rent::Rent, Sysvar},
     AccountView, Address, ProgramResult,
 };
 use pinocchio_system::instructions::{Allocate, Assign};
@@ -150,10 +149,9 @@ pub fn initialize(accounts: &mut [AccountView], instruction_data: &[u8]) -> Prog
             }
             .invoke_signed(signer)?;
 
-            // `space` is guranteed to be within the permitted limits.
-            let minimum_balance = Rent::get()?.minimum_balance_unchecked(space);
-
-            if metadata.lamports() < minimum_balance {
+            // The metadata account must have non-zero lamports. The runtime will
+            // then ensure that the account is rent exempt.
+            if metadata.lamports() == 0 {
                 return Err(ProgramError::AccountNotRentExempt);
             }
 

--- a/program/src/processor/initialize.rs
+++ b/program/src/processor/initialize.rs
@@ -62,6 +62,8 @@ pub fn initialize(accounts: &mut [AccountView], instruction_data: &[u8]) -> Prog
     //   the remaining instruction data is used as the metadata account data; OR be a
     //   pre-allocated buffer (i.e. `discriminator = 1`), in which case, no remaining
     //   instruction data is allowed as the data must already be written to the account
+    // - must have lamports (pre-funded account); the runtime will ensure that the
+    //   account is rent exempt
 
     let (derived_metadata, bump) = if canonical {
         derive_program_address(&[program.address().as_array(), args.seed.as_ref()], &ID)
@@ -149,12 +151,6 @@ pub fn initialize(accounts: &mut [AccountView], instruction_data: &[u8]) -> Prog
             }
             .invoke_signed(signer)?;
 
-            // The metadata account must have non-zero lamports. The runtime will
-            // then ensure that the account is rent exempt.
-            if metadata.lamports() == 0 {
-                return Err(ProgramError::AccountNotRentExempt);
-            }
-
             // SAFETY: scoped mutable borrow of `metadata` account data. The data is
             // guaranteed to be allocated and assigned to the program.
             let metadata_account_data = unsafe { metadata.borrow_unchecked_mut() };
@@ -176,6 +172,12 @@ pub fn initialize(accounts: &mut [AccountView], instruction_data: &[u8]) -> Prog
             remaining_data.len()
         }
     };
+
+    // The metadata account must have lamports. The runtime will
+    // then ensure that the account is rent exempt.
+    if metadata.lamports() == 0 {
+        return Err(ProgramError::AccountNotRentExempt);
+    }
 
     // Initialize the metadata account.
 

--- a/program/src/processor/set_data.rs
+++ b/program/src/processor/set_data.rs
@@ -46,6 +46,8 @@ pub fn set_data(accounts: &mut [AccountView], instruction_data: &[u8]) -> Progra
         // metadata
         // - must be initialized
         // - must be mutable
+        // - must be rent exempt (pre-funded account) since we are reallocating the
+        //   account (checked by the runtime)
 
         // SAFETY: Scoped immutable borrow of `metadata` account data for validation.
         let metadata_account_data = unsafe { metadata.borrow_unchecked() };

--- a/program/src/processor/write.rs
+++ b/program/src/processor/write.rs
@@ -31,8 +31,8 @@ pub fn write(accounts: &mut [AccountView], instruction_data: &[u8]) -> ProgramRe
 
     // target_buffer
     // - must be initialized
-    // - must be rent exempt (pre-funded account) since we are reallocating the buffer
-    //   account (checked by the runtime)
+    // - must be rent exempt (pre-funded account) since we are reallocating
+    //   the account (checked by the runtime)
     //
     // source_buffer (if `args.data()` is empty)
     // - must be initialized

--- a/program/src/processor/write.rs
+++ b/program/src/processor/write.rs
@@ -1,10 +1,6 @@
 use core::cmp::max;
 
-use pinocchio::{
-    error::ProgramError,
-    sysvars::{rent::Rent, Sysvar},
-    AccountView, ProgramResult, Resize,
-};
+use pinocchio::{error::ProgramError, AccountView, ProgramResult, Resize};
 
 use crate::state::{buffer::Buffer, header::Header, AccountDiscriminator};
 
@@ -36,7 +32,7 @@ pub fn write(accounts: &mut [AccountView], instruction_data: &[u8]) -> ProgramRe
     // target_buffer
     // - must be initialized
     // - must be rent exempt (pre-funded account) since we are reallocating the buffer
-    //   account
+    //   account (checked by the runtime)
     //
     // source_buffer (if `args.data()` is empty)
     // - must be initialized
@@ -94,12 +90,6 @@ pub fn write(accounts: &mut [AccountView], instruction_data: &[u8]) -> ProgramRe
         // `offset` is a `u32` value and `source_data` is at most `10_000_000` bytes.
         (max(data.len(), offset + source_data.len()), source_data)
     };
-
-    let minimum_balance = Rent::get()?.try_minimum_balance(required_length)?;
-
-    if target_buffer.lamports() < minimum_balance {
-        return Err(ProgramError::AccountNotRentExempt);
-    }
 
     // Writes the source data to the buffer account.
 

--- a/program/src/processor/write.rs
+++ b/program/src/processor/write.rs
@@ -32,7 +32,8 @@ pub fn write(accounts: &mut [AccountView], instruction_data: &[u8]) -> ProgramRe
     // target_buffer
     // - must be initialized
     // - must be rent exempt (pre-funded account) since we are reallocating
-    //   the account (checked by the runtime)
+    //   the account (checked by the runtime); both `allocate` and `initialize`
+    //   ensure that the account has at least some lamports
     //
     // source_buffer (if `args.data()` is empty)
     // - must be initialized

--- a/program/tests/extend.rs
+++ b/program/tests/extend.rs
@@ -300,31 +300,6 @@ fn fail_extend_with_wrong_authority() {
 }
 
 #[test]
-fn fail_extend_without_rent_for_growth() {
-    let buffer_key = Pubkey::new_unique();
-    let buffer_account =
-        create_funded_account(minimum_balance_for(Buffer::LEN), system_program::ID);
-
-    process_instructions(
-        &[
-            (
-                &allocate(&buffer_key, &buffer_key, None, None, None),
-                &[Check::success()],
-            ),
-            (
-                &extend(&buffer_key, &buffer_key, None, None, 1),
-                &[Check::err(ProgramError::AccountNotRentExempt)],
-            ),
-        ],
-        &[
-            (buffer_key, buffer_account),
-            (PROGRAM_ID, Account::default()),
-            keyed_account_for_system_program(),
-        ],
-    );
-}
-
-#[test]
 fn fail_extend_uninitialized_account() {
     let account_key = Pubkey::new_unique();
 

--- a/program/tests/initialize.rs
+++ b/program/tests/initialize.rs
@@ -378,7 +378,7 @@ fn fail_initialize_with_wrong_metadata_pda() {
 }
 
 #[test]
-fn fail_initialize_without_rent_exemption() {
+fn fail_initialize_unfunded_metadata() {
     let authority_key = Pubkey::new_unique();
 
     let program_data_key = Pubkey::new_unique();

--- a/program/tests/write.rs
+++ b/program/tests/write.rs
@@ -265,28 +265,3 @@ fn fail_write_from_same_buffer() {
         ],
     );
 }
-
-#[test]
-fn fail_write_without_rent_for_growth() {
-    let buffer_key = Pubkey::new_unique();
-    let buffer_account =
-        create_funded_account(minimum_balance_for(Buffer::LEN), system_program::ID);
-
-    process_instructions(
-        &[
-            (
-                &allocate(&buffer_key, &buffer_key, None, None, None),
-                &[Check::success()],
-            ),
-            (
-                &write(&buffer_key, &buffer_key, None, 0, &[1]),
-                &[Check::err(ProgramError::AccountNotRentExempt)],
-            ),
-        ],
-        &[
-            (buffer_key, buffer_account),
-            (PROGRAM_ID, Account::default()),
-            keyed_account_for_system_program(),
-        ],
-    );
-}


### PR DESCRIPTION
### Problem

Currently, `Allocate`, `Extend`, `Initialize` and `Write` include explicit minimum rent exempt, but could rely on the runtime instead.

### Solution

For `Allocate` and `Initialize`, replace the minimum rent check by a check that account must have lamports; these are the only 2 instructions that can create the PDA. Remove the rent exempt check in `Extend` and `Write` since these instructions require an initialized account with data.