### PR TITLE
program: no_std

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4578,9 +4578,9 @@ dependencies = [
 
 [[package]]
 name = "solana-security-txt"
-version = "1.1.1"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "468aa43b7edb1f9b7b7b686d5c3aeb6630dc1708e86e31343499dd5c4d775183"
+checksum = "c94a02d486b28f219a4f8f5d7dd93cbfbb93c9f466cb7871c22e50cd5ae9a7a2"
 
 [[package]]
 name = "solana-seed-derivable"

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -24,7 +24,7 @@ crate-type = ["cdylib", "lib"]
 pinocchio = { version = "0.11.1", features = ["account-resize"] }
 pinocchio-system = "0.6.1"
 solana-program-log = { version = "1.0", default-features = false }
-solana-security-txt = "1.1.1"
+solana-security-txt = "1.1.3"
 
 [dev-dependencies]
 mollusk-svm = { version = "0.4" }

--- a/program/src/entrypoint.rs
+++ b/program/src/entrypoint.rs
@@ -1,5 +1,5 @@
 use pinocchio::{
-    default_panic_handler, error::ProgramError, no_allocator, program_entrypoint, AccountView,
+    error::ProgramError, no_allocator, nostd_panic_handler, program_entrypoint, AccountView,
     Address, ProgramResult,
 };
 
@@ -14,7 +14,7 @@ use crate::{
 
 program_entrypoint!(process_instruction);
 // Logs panic output.
-default_panic_handler!();
+nostd_panic_handler!();
 // No allocator is used.
 no_allocator!();
 

--- a/program/src/lib.rs
+++ b/program/src/lib.rs
@@ -1,4 +1,5 @@
 //! A program to store metadata information for programs.
+#![no_std]
 
 pub mod entrypoint;
 pub mod error;


### PR DESCRIPTION
### Problem

The program can be `no_std`, but it is not.

### Solution

- Update `solana-security-txt` to a new version that supports `no_std`.
- Change the panic handler to `nostd_panic_handler`.
- Add the `no_std` attribute.