### PR TITLE
program: Bump dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2580,9 +2580,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pinocchio"
-version = "0.11.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d707cea2843c1a2fd8ec49e4116ce3fdaedcd552a3ee168b03ce60e627fc0f62"
+checksum = "a6cababcb62a2e739c7078ae16eda02789a6e3edd21bbdded864e85c38a7914d"
 dependencies = [
  "solana-account-view",
  "solana-address 2.6.0",
@@ -4715,11 +4715,11 @@ checksum = "4f04fa578707b3612b095f0c8e19b66a1233f7c42ca8082fcb3b745afcc0add6"
 
 [[package]]
 name = "solana-program-log"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b26115ff9ec592bb4407379c82e7f00b9d0ae4e3fac80c3fd28c932aec852dc6"
+checksum = "ffd48ddef444e6db138fb11bdb9ab8117bb830a78cef051a453454de5613039b"
 dependencies = [
- "solana-define-syscall 4.0.1",
+ "solana-define-syscall 5.1.0",
 ]
 
 [[package]]

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -21,9 +21,9 @@ name = "spl_program_metadata"
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-pinocchio = { version = "0.11.1", features = ["account-resize"] }
+pinocchio = { version = "0.11.2", features = ["account-resize"] }
 pinocchio-system = "0.6.1"
-solana-program-log = { version = "1.0", default-features = false }
+solana-program-log = { version = "1.2.0", default-features = false }
 solana-security-txt = "1.1.3"
 
 [dev-dependencies]


### PR DESCRIPTION
### Problem

Both `pinocchio` and `solana-program-log` have new patch versions of their crate, which the program is not using.

### Solution

Bump both `pinocchio` and `solana-program-log` dependencies.