### PR TITLE
Replace @iarna/toml with smol-toml to make the JS client isomorphic

### DIFF
--- a/clients/js/package.json
+++ b/clients/js/package.json
@@ -47,12 +47,12 @@
         "prepublishOnly": "pnpm build"
     },
     "dependencies": {
-        "@iarna/toml": "^2.2.5",
         "@solana-program/compute-budget": "^0.15.0",
         "@solana-program/system": "^0.12.0",
         "commander": "^13.0.0",
         "pako": "^2.1.0",
         "picocolors": "^1.1.1",
+        "smol-toml": "^1.6.1",
         "yaml": "^2.7.0"
     },
     "devDependencies": {

--- a/clients/js/pnpm-lock.yaml
+++ b/clients/js/pnpm-lock.yaml
@@ -8,9 +8,6 @@ importers:
 
   .:
     dependencies:
-      '@iarna/toml':
-        specifier: ^2.2.5
-        version: 2.2.5
       '@solana-program/compute-budget':
         specifier: ^0.15.0
         version: 0.15.0(@solana/kit@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))
@@ -26,6 +23,9 @@ importers:
       picocolors:
         specifier: ^1.1.1
         version: 1.1.1
+      smol-toml:
+        specifier: ^1.6.1
+        version: 1.6.1
       yaml:
         specifier: ^2.7.0
         version: 2.7.0
@@ -236,9 +236,6 @@ packages:
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
-
-  '@iarna/toml@2.2.5':
-    resolution: {integrity: sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==}
 
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
@@ -1653,6 +1650,10 @@ packages:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
 
+  smol-toml@1.6.1:
+    resolution: {integrity: sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg==}
+    engines: {node: '>= 18'}
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
@@ -1994,8 +1995,6 @@ snapshots:
 
   '@esbuild/win32-x64@0.24.2':
     optional: true
-
-  '@iarna/toml@2.2.5': {}
 
   '@isaacs/cliui@8.0.2':
     dependencies:
@@ -3286,6 +3285,8 @@ snapshots:
   siginfo@2.0.0: {}
 
   signal-exit@4.1.0: {}
+
+  smol-toml@1.6.1: {}
 
   source-map-js@1.2.1: {}
 

--- a/clients/js/src/fetchMetadataContent.ts
+++ b/clients/js/src/fetchMetadataContent.ts
@@ -1,4 +1,4 @@
-import { parse as parseToml } from '@iarna/toml';
+import { parse as parseToml } from 'smol-toml';
 import { Address, assertAccountsExist, GetAccountInfoApi, GetMultipleAccountsApi, Rpc } from '@solana/kit';
 import { parse as parseYaml } from 'yaml';
 

--- a/clients/js/src/fetchMetadataContent.ts
+++ b/clients/js/src/fetchMetadataContent.ts
@@ -1,5 +1,5 @@
-import { parse as parseToml } from 'smol-toml';
 import { Address, assertAccountsExist, GetAccountInfoApi, GetMultipleAccountsApi, Rpc } from '@solana/kit';
+import { parse as parseToml } from 'smol-toml';
 import { parse as parseYaml } from 'yaml';
 
 import { fetchAllMaybeMetadata, fetchMetadataFromSeeds, findMetadataPda, Format, SeedArgs } from './generated';


### PR DESCRIPTION
## Summary

Makes the `@solana-program/program-metadata` JS client isomorphic (browser-compatible) by replacing the TOML parser.

`@iarna/toml` relies on Node's `Buffer` global, which breaks the client in browser environments. It was the **last Node-only runtime dependency** in the library's import graph. This swaps it for [`smol-toml`](https://github.com/squirrelchat/smol-toml) — a pure-JS, zero-dependency, TOML 1.0.0-compliant parser that runs in any environment and exposes a drop-in `parse` export.

## Changes

- `clients/js/src/fetchMetadataContent.ts`: import `parse` from `smol-toml` instead of `@iarna/toml`
- `clients/js/package.json` + lockfile: swap the dependency

## Verification

- ✅ `pnpm build`, typecheck, and `pnpm lint` pass
- ✅ Lockfile consistent (`--frozen-lockfile`); `@iarna/toml` fully removed
- ✅ Confirmed the shipped library bundle (`dist/src/index.{js,mjs}`) contains no references to `fs`/`path`/`node:`/`commander` — CLI-only deps stay isolated in the separate CLI bundle entry

## Notes

- Behavioral nuance: integers above `Number.MAX_SAFE_INTEGER` now throw a `TomlError` (smol-toml default) rather than being returned as `BigInt`. This is an unlikely edge case for program metadata and arguably safer than silent precision loss.