### PR TITLE
dependency: Bump quinn-proto version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2716,9 +2716,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.12"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49df843a9161c85bb8aae55f101bc0bac8bcafd637a620d9122fd7e0b2f7422e"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes",
  "getrandom 0.3.2",


### PR DESCRIPTION
### Problem

CI is currently failing the cargo-audit step because of `quinn-proto` version.

### Solution

Bump the `quinn-proto` version.