### PR TITLE
Fix 'lenght' typos in test comments

### DIFF
--- a/program/tests/allocate.rs
+++ b/program/tests/allocate.rs
@@ -39,7 +39,7 @@ fn test_allocate_canonical() {
             ),
             &[
                 Check::success(),
-                // data lenght
+                // data length
                 Check::account(&buffer_key).space(Buffer::LEN).build(),
                 // account discriminator
                 Check::account(&buffer_key).data_slice(0, &[1]).build(),
@@ -86,7 +86,7 @@ fn test_allocate_non_canonical() {
             ),
             &[
                 Check::success(),
-                // data lenght
+                // data length
                 Check::account(&buffer_key).space(Buffer::LEN).build(),
                 // account discriminator
                 Check::account(&buffer_key).data_slice(0, &[1]).build(),
@@ -114,7 +114,7 @@ fn test_allocate_keypair() {
             &allocate(&buffer_key, &buffer_key, None, None, None),
             &[
                 Check::success(),
-                // data lenght
+                // data length
                 Check::account(&buffer_key).space(Buffer::LEN).build(),
                 // account discriminator
                 Check::account(&buffer_key).data_slice(0, &[1]).build(),
@@ -139,7 +139,7 @@ fn test_allocate_with_empty_account() {
             &allocate(&buffer_key, &buffer_key, None, None, None),
             &[
                 Check::success(),
-                // data lenght
+                // data length
                 Check::account(&buffer_key).space(Buffer::LEN).build(),
                 // account discriminator
                 Check::account(&buffer_key).data_slice(0, &[1]).build(),
@@ -200,7 +200,7 @@ fn test_allocate_with_funded_canonical_account() {
             ),
             &[
                 Check::success(),
-                // data lenght
+                // data length
                 Check::account(&buffer_key).space(Buffer::LEN).build(),
                 // account discriminator
                 Check::account(&buffer_key).data_slice(0, &[1]).build(),
@@ -248,7 +248,7 @@ fn test_allocate_with_funded_non_canonical_account() {
             ),
             &[
                 Check::success(),
-                // data lenght
+                // data length
                 Check::account(&buffer_key).space(Buffer::LEN).build(),
                 // account discriminator
                 Check::account(&buffer_key).data_slice(0, &[1]).build(),
@@ -276,7 +276,7 @@ fn test_allocate_with_funded_keypair_account() {
             &allocate(&buffer_key, &buffer_key, None, None, None),
             &[
                 Check::success(),
-                // data lenght
+                // data length
                 Check::account(&buffer_key).space(Buffer::LEN).build(),
                 // account discriminator
                 Check::account(&buffer_key).data_slice(0, &[1]).build(),

--- a/program/tests/extend.rs
+++ b/program/tests/extend.rs
@@ -44,7 +44,7 @@ fn test_extend_canonical_buffer() {
                     Check::success(),
                     // account discriminator
                     Check::account(&buffer_key).data_slice(0, &[1]).build(),
-                    // data lenght
+                    // data length
                     Check::account(&buffer_key).space(Buffer::LEN).build(),
                 ],
             ),
@@ -58,7 +58,7 @@ fn test_extend_canonical_buffer() {
                 ),
                 &[
                     Check::success(),
-                    // data lenght
+                    // data length
                     Check::account(&buffer_key)
                         .space(Buffer::LEN + EXTEND_LENGTH)
                         .build(),
@@ -114,7 +114,7 @@ fn test_extend_non_canonical_buffer() {
                 ),
                 &[
                     Check::success(),
-                    // data lenght
+                    // data length
                     Check::account(&buffer_key).space(Buffer::LEN).build(),
                     // account discriminator
                     Check::account(&buffer_key).data_slice(0, &[1]).build(),
@@ -130,7 +130,7 @@ fn test_extend_non_canonical_buffer() {
                 ),
                 &[
                     Check::success(),
-                    // data lenght
+                    // data length
                     Check::account(&buffer_key)
                         .space(Buffer::LEN + EXTEND_LENGTH)
                         .build(),
@@ -165,7 +165,7 @@ fn test_extend_keypair_buffer() {
                 &allocate(&buffer_key, &buffer_key, None, None, None),
                 &[
                     Check::success(),
-                    // data lenght
+                    // data length
                     Check::account(&buffer_key).space(Buffer::LEN).build(),
                     // account discriminator
                     Check::account(&buffer_key).data_slice(0, &[1]).build(),
@@ -175,7 +175,7 @@ fn test_extend_keypair_buffer() {
                 &extend(&buffer_key, &buffer_key, None, None, EXTEND_LENGTH as u16),
                 &[
                     Check::success(),
-                    // data lenght
+                    // data length
                     Check::account(&buffer_key)
                         .space(Buffer::LEN + EXTEND_LENGTH)
                         .build(),

--- a/program/tests/trim.rs
+++ b/program/tests/trim.rs
@@ -213,7 +213,7 @@ fn test_trim_buffer() {
                 &allocate(&buffer_key, &buffer_key, None, None, None),
                 &[
                     Check::success(),
-                    // data lenght
+                    // data length
                     Check::account(&buffer_key).space(Buffer::LEN).build(),
                     // account discriminator
                     Check::account(&buffer_key).data_slice(0, &[1]).build(),
@@ -227,7 +227,7 @@ fn test_trim_buffer() {
                 &trim(&buffer_key, &buffer_key, None, None, &destination_key),
                 &[
                     Check::success(),
-                    // data lenght
+                    // data length
                     Check::account(&buffer_key).space(Buffer::LEN).build(),
                     // account discriminator
                     Check::account(&buffer_key).data_slice(0, &[1]).build(),


### PR DESCRIPTION
Fixes a spelling typo in test comments: `lenght` should be `length`. Fifteen occurrences of the `// data lenght` comment across `program/tests/allocate.rs`, `program/tests/extend.rs`, and `program/tests/trim.rs`. No code change.
