### PR TITLE
feat: add `--tx-version` option to build legacy transactions

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,11 @@ npx @solana-program/program-metadata@latest set-buffer-authority <buffer-address
 npx @solana-program/program-metadata@latest write idl <program-address> --buffer <buffer-address> --export <multisig-address> --export-encoding base58 --close-buffer <your-address-to-get-the-buffer-rent-back>
 ```
 
-If your multisig only accepts legacy transactions, add `--legacy` to the export command.
+Squads v3 only accepts legacy transactions. If your multisig is on Squads v3, add the `--legacy` flag so the exported transaction is a legacy transaction instead of a version 0 transaction:
+
+```bash
+npx @solana-program/program-metadata@latest write idl <program-address> --buffer <buffer-address> --export <multisig-address> --export-encoding base58 --close-buffer <your-address-to-get-the-buffer-rent-back> --legacy
+```
 
 4. Sign the transaction in your multisig and send it
 

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Using a buffer account you can split the metadata update into the uploading of t
 - `--rpc <string>`: Custom RPC URL
 - `--export [address]`: Export transactions instead of running them. Optionally specify an override authority address.
 - `--export-encoding <encoding>`: How to encode exported transactions. Choices: none, utf8, base58, base64 (default: base64)
-- `--legacy`: Export legacy transactions instead of version 0 transactions. Requires `--export`.
+- `--tx-version <version>`: Transaction version to build. Choices: legacy, 0 (default: 0)
 - `-h, --help`: Show help for command
 
 #### Squads Multisig
@@ -144,10 +144,10 @@ npx @solana-program/program-metadata@latest set-buffer-authority <buffer-address
 npx @solana-program/program-metadata@latest write idl <program-address> --buffer <buffer-address> --export <multisig-address> --export-encoding base58 --close-buffer <your-address-to-get-the-buffer-rent-back>
 ```
 
-Squads v3 only accepts legacy transactions. If your multisig is on Squads v3, add the `--legacy` flag so the exported transaction is a legacy transaction instead of a version 0 transaction:
+Squads v3 only accepts legacy transactions. If your multisig is on Squads v3, add `--tx-version legacy` so the exported transaction is a legacy transaction instead of a version 0 transaction:
 
 ```bash
-npx @solana-program/program-metadata@latest write idl <program-address> --buffer <buffer-address> --export <multisig-address> --export-encoding base58 --close-buffer <your-address-to-get-the-buffer-rent-back> --legacy
+npx @solana-program/program-metadata@latest write idl <program-address> --buffer <buffer-address> --export <multisig-address> --export-encoding base58 --close-buffer <your-address-to-get-the-buffer-rent-back> --tx-version legacy
 ```
 
 4. Sign the transaction in your multisig and send it

--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ Using a buffer account you can split the metadata update into the uploading of t
 - `--rpc <string>`: Custom RPC URL
 - `--export [address]`: Export transactions instead of running them. Optionally specify an override authority address.
 - `--export-encoding <encoding>`: How to encode exported transactions. Choices: none, utf8, base58, base64 (default: base64)
+- `--legacy`: Export legacy transactions instead of version 0 transactions. Requires `--export`.
 - `-h, --help`: Show help for command
 
 #### Squads Multisig
@@ -142,6 +143,8 @@ npx @solana-program/program-metadata@latest set-buffer-authority <buffer-address
 ```bash
 npx @solana-program/program-metadata@latest write idl <program-address> --buffer <buffer-address> --export <multisig-address> --export-encoding base58 --close-buffer <your-address-to-get-the-buffer-rent-back>
 ```
+
+If your multisig only accepts legacy transactions, add `--legacy` to the export command.
 
 4. Sign the transaction in your multisig and send it
 

--- a/clients/js/src/cli/options.ts
+++ b/clients/js/src/cli/options.ts
@@ -1,5 +1,5 @@
 import { type Address, type MicroLamports } from '@solana/kit';
-import { Option } from 'commander';
+import { InvalidArgumentError, Option } from 'commander';
 
 import { Compression, Encoding, Format } from '../generated';
 import { logErrorAndExit } from './logs';
@@ -12,7 +12,7 @@ export type GlobalOptions = KeypairOption &
     RpcOption &
     ExportOption &
     ExportEncodingOption &
-    LegacyOption;
+    TransactionVersionOption;
 
 export function setGlobalOptions(command: CustomCommand) {
     command
@@ -22,7 +22,7 @@ export function setGlobalOptions(command: CustomCommand) {
         .addOption(rpcOption)
         .addOption(exportOption)
         .addOption(exportEncodingOption)
-        .addOption(legacyOption);
+        .addOption(transactionVersionOption);
 }
 
 export type KeypairOption = { keypair?: string };
@@ -68,11 +68,24 @@ export const exportEncodingOption = new Option(
         (value: string): ExportEncoding => (value === 'instruction-list' ? 'instruction-list' : encodingParser(value)),
     );
 
-export type LegacyOption = { legacy: boolean };
-export const legacyOption = new Option(
-    '--legacy',
-    'Export legacy transactions instead of version 0 transactions. Requires `--export`.',
-).default(false);
+export type TransactionVersion = 'legacy' | 0;
+export type TransactionVersionOption = { txVersion: TransactionVersion };
+export const transactionVersionOption = new Option(
+    '--tx-version <version>',
+    'Transaction version to build. Squads v3 only accepts legacy transactions.',
+)
+    .choices(['legacy', '0'])
+    .default(0, '0')
+    .argParser((value: string): TransactionVersion => {
+        switch (value) {
+            case 'legacy':
+                return 'legacy';
+            case '0':
+                return 0;
+            default:
+                throw new InvalidArgumentError('Allowed choices are legacy, 0.');
+        }
+    });
 
 export type WriteOptions = TextOption &
     UrlOption &

--- a/clients/js/src/cli/options.ts
+++ b/clients/js/src/cli/options.ts
@@ -11,7 +11,8 @@ export type GlobalOptions = KeypairOption &
     PriorityFeesOption &
     RpcOption &
     ExportOption &
-    ExportEncodingOption;
+    ExportEncodingOption &
+    LegacyOption;
 
 export function setGlobalOptions(command: CustomCommand) {
     command
@@ -20,7 +21,8 @@ export function setGlobalOptions(command: CustomCommand) {
         .addOption(priorityFeesOption)
         .addOption(rpcOption)
         .addOption(exportOption)
-        .addOption(exportEncodingOption);
+        .addOption(exportEncodingOption)
+        .addOption(legacyOption);
 }
 
 export type KeypairOption = { keypair?: string };
@@ -65,6 +67,12 @@ export const exportEncodingOption = new Option(
     .argParser(
         (value: string): ExportEncoding => (value === 'instruction-list' ? 'instruction-list' : encodingParser(value)),
     );
+
+export type LegacyOption = { legacy: boolean };
+export const legacyOption = new Option(
+    '--legacy',
+    'Export legacy transactions instead of version 0 transactions. Requires `--export`.',
+).default(false);
 
 export type WriteOptions = TextOption &
     UrlOption &

--- a/clients/js/src/cli/utils.ts
+++ b/clients/js/src/cli/utils.ts
@@ -35,7 +35,7 @@ import {
     TransactionPlanExecutor,
     TransactionSigner,
 } from '@solana/kit';
-import { solanaRpc } from '@solana/kit-plugin-rpc';
+import { solanaRpc, TransactionPlannerConfig } from '@solana/kit-plugin-rpc';
 import { identity, payer } from '@solana/kit-plugin-signer';
 import { Command } from 'commander';
 import picocolors from 'picocolors';
@@ -80,10 +80,6 @@ export class CustomCommand extends Command {
 export type Client = Awaited<ReturnType<typeof getClient>>;
 
 export async function getClient(options: GlobalOptions) {
-    if (options.legacy && !options.export) {
-        logErrorAndExit('The `--legacy` option requires the `--export` option.');
-    }
-
     const configs = getSolanaConfigs();
     const rpcUrl = getRpcUrl(options, configs);
     const rpcSubscriptionsUrl = getRpcSubscriptionsUrl(rpcUrl, configs);
@@ -96,15 +92,26 @@ export async function getClient(options: GlobalOptions) {
             solanaRpc({
                 rpcUrl,
                 rpcSubscriptionsUrl,
-                transactionConfig: {
-                    microLamportsPerComputeUnit: options.priorityFees,
-                    version: options.legacy ? 'legacy' : 0,
-                },
+                transactionConfig: getTransactionConfig(options),
             }),
         )
         .use(programMetadataProgram())
         .use(cliConfigs(configs))
         .use(cliRunOrExport(options));
+}
+
+/**
+ * Builds the transaction planner config for the requested transaction version.
+ * The config shape is discriminated by `version`: legacy and version 0
+ * transactions express priority fees per compute unit, while version 1 will
+ * use a total fee in lamports.
+ */
+function getTransactionConfig(options: GlobalOptions): TransactionPlannerConfig {
+    switch (options.txVersion) {
+        case 'legacy':
+        case 0:
+            return { microLamportsPerComputeUnit: options.priorityFees, version: options.txVersion };
+    }
 }
 
 /**

--- a/clients/js/src/cli/utils.ts
+++ b/clients/js/src/cli/utils.ts
@@ -80,6 +80,10 @@ export class CustomCommand extends Command {
 export type Client = Awaited<ReturnType<typeof getClient>>;
 
 export async function getClient(options: GlobalOptions) {
+    if (options.legacy && !options.export) {
+        logErrorAndExit('The `--legacy` option requires the `--export` option.');
+    }
+
     const configs = getSolanaConfigs();
     const rpcUrl = getRpcUrl(options, configs);
     const rpcSubscriptionsUrl = getRpcSubscriptionsUrl(rpcUrl, configs);
@@ -92,7 +96,10 @@ export async function getClient(options: GlobalOptions) {
             solanaRpc({
                 rpcUrl,
                 rpcSubscriptionsUrl,
-                transactionConfig: { microLamportsPerComputeUnit: options.priorityFees },
+                transactionConfig: {
+                    microLamportsPerComputeUnit: options.priorityFees,
+                    version: options.legacy ? 'legacy' : 0,
+                },
             }),
         )
         .use(programMetadataProgram())


### PR DESCRIPTION
## Summary

Adds a global `--tx-version <version>` option to the CLI so users can build legacy transactions instead of version 0 transactions. Squads v3 only accepts legacy transactions when importing a base58 encoded transaction, so exports for a v3 multisig failed to import.

## Usage

  ```bash
  npx @solana-program/program-metadata@latest write idl <program-address> \
    --buffer <buffer-address> \
    --export <multisig-address> \
    --export-encoding base58 \
    --close-buffer <your-address> \
    --tx-version legacy