### PR TITLE
Add a devEngines Node floor to the JS client

### DIFF
--- a/clients/js/package.json
+++ b/clients/js/package.json
@@ -73,5 +73,12 @@
     },
     "peerDependencies": {
         "@solana/kit": "^8.0.0"
+    },
+    "devEngines": {
+        "runtime": {
+            "name": "node",
+            "version": ">=24.0.0",
+            "onFail": "error"
+        }
     }
 }


### PR DESCRIPTION
This PR declares the Node 24 dev-tooling floor for the JS client via `devEngines.runtime`. Unlike `engines`, the field only applies to the repository's own development — consumers installing the published package are unaffected — and npm ≥ 10.9 fails with a clear error for contributors on an older local Node instead of a cryptic oxc/vitest one.