### PR TITLE
Surface underlying transaction errors in the CLI

### DIFF
--- a/clients/js/pnpm-workspace.yaml
+++ b/clients/js/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+allowBuilds:
+  esbuild: false

--- a/clients/js/src/cli/utils.ts
+++ b/clients/js/src/cli/utils.ts
@@ -9,6 +9,7 @@ import {
     address,
     ClientWithRpc,
     ClientWithTransactionPlanning,
+    ClientWithTransactionSending,
     Commitment,
     compileTransaction,
     createClient,
@@ -32,7 +33,6 @@ import {
     SolanaRpcSubscriptionsApi,
     TransactionMessage,
     TransactionPlan,
-    TransactionPlanExecutor,
     TransactionSigner,
 } from '@solana/kit';
 import { solanaRpc, TransactionPlannerConfig } from '@solana/kit-plugin-rpc';
@@ -131,10 +131,7 @@ function cliConfigs(configs: SolanaConfigs) {
  */
 function cliRunOrExport(options: ExportOption & ExportEncodingOption) {
     return <
-        T extends ClientWithRpc<GetLatestBlockhashApi> &
-            ClientWithTransactionPlanning & {
-                transactionPlanExecutor: TransactionPlanExecutor;
-            },
+        T extends ClientWithRpc<GetLatestBlockhashApi> & ClientWithTransactionPlanning & ClientWithTransactionSending,
     >(
         client: T,
     ) =>
@@ -144,8 +141,8 @@ function cliRunOrExport(options: ExportOption & ExportEncodingOption) {
                 if (options.export) {
                     await exportTransactionPlan(transactionPlan, client, options);
                 } else {
-                    // TODO: progress + error handling.
-                    await client.transactionPlanExecutor(transactionPlan);
+                    // TODO: progress reporting.
+                    await client.sendTransactions(transactionPlan);
                     logSuccess('Operation executed successfully');
                 }
             },


### PR DESCRIPTION
This PR fixes the CLI swallowing useful transaction errors when executing an instruction plan (e.g. uploading an IDL). The `runOrExport` helper called the deprecated low-level `transactionPlanExecutor`, which threw a generic "The provided transaction plan failed to execute" error that hid the real cause. It now uses the client's `sendTransactions` method, which unwraps failures into readable messages reporting which transaction failed and its underlying program error.